### PR TITLE
Ensure generated moves flip side to move

### DIFF
--- a/src/eval.zig
+++ b/src/eval.zig
@@ -505,6 +505,17 @@ test "minimax finds a move in checkmate position" {
     }
 }
 
+test "minimax awards checkmate score when white can mate immediately" {
+    var board = Board{ .position = b.Position.emptyboard() };
+    board.position.whitepieces.Queen.position = c.H7;
+    board.position.whitepieces.Rook[0].position = c.G1;
+    board.position.blackpieces.King.position = c.H8;
+    board.position.sidetomove = 0; // White to move
+
+    const score = minimax(board, 2, -INFINITY_SCORE, INFINITY_SCORE, true);
+    try std.testing.expectEqual(CHECKMATE_SCORE, score);
+}
+
 test "evaluate considers piece position" {
     // Create two boards with the same material but different piece positions
     var board1 = Board{ .position = b.Position.emptyboard() };

--- a/src/eval.zig
+++ b/src/eval.zig
@@ -177,8 +177,8 @@ pub fn findBestMove(board: Board, depth: u8) ?Board {
     const MoveScore = struct { move: Board, score: i32 };
 
     // Create a list of moves with their scores for sorting
-    var move_scores = std.ArrayList(MoveScore).init(std.heap.page_allocator);
-    defer move_scores.deinit();
+    var move_scores: [1024]MoveScore = undefined;
+    var move_score_len: usize = 0;
 
     // First, evaluate all moves with a shallow search to get initial scores
     for (moves) |move| {
@@ -215,11 +215,14 @@ pub fn findBestMove(board: Board, depth: u8) ?Board {
         }
 
         // Add the move and its score to our list
-        move_scores.append(.{ .move = move, .score = score }) catch continue;
+        if (move_score_len == move_scores.len) break;
+        move_scores[move_score_len] = .{ .move = move, .score = score };
+        move_score_len += 1;
     }
 
     // Sort moves by score (descending)
-    std.mem.sort(MoveScore, move_scores.items, {}, struct {
+    const move_scores_slice = move_scores[0..move_score_len];
+    std.mem.sort(MoveScore, move_scores_slice, {}, struct {
         fn compare(_: void, a: MoveScore, b_move: MoveScore) bool {
             return a.score > b_move.score;
         }
@@ -230,7 +233,7 @@ pub fn findBestMove(board: Board, depth: u8) ?Board {
     var bestMoveIndex: usize = 0;
     const maximizingPlayer = board.position.sidetomove == 0; // White is maximizing
 
-    for (move_scores.items, 0..) |move_data, i| {
+    for (move_scores_slice, 0..) |move_data, i| {
         // For each move, evaluate the resulting position
         const score = minimax(move_data.move, depth - 1, -INFINITY_SCORE, INFINITY_SCORE, !maximizingPlayer);
 
@@ -241,8 +244,8 @@ pub fn findBestMove(board: Board, depth: u8) ?Board {
         }
     }
 
-    if (move_scores.items.len > 0) {
-        return move_scores.items[bestMoveIndex].move;
+    if (move_score_len > 0) {
+        return move_scores_slice[bestMoveIndex].move;
     } else if (moves.len > 0) {
         // Fallback if move scoring failed
         return moves[0];

--- a/src/moves.zig
+++ b/src/moves.zig
@@ -803,6 +803,7 @@ pub fn allvalidmoves(board: b.Board) []b.Board {
 
     // Copy board and set side to move for each generated move
     var boardCopy = board;
+    const next_side: u8 = if (board.position.sidetomove == 0) 1 else 0;
 
     if (board.position.sidetomove == 0) { // White pieces
         // King moves
@@ -811,6 +812,7 @@ pub fn allvalidmoves(board: b.Board) []b.Board {
             // Only allow moves that don't leave us in check
             if (!s.isCheck(move, true)) {
                 boardCopy = move;
+                boardCopy.position.sidetomove = next_side;
                 moves[movecount] = boardCopy;
                 movecount += 1;
             }
@@ -821,6 +823,7 @@ pub fn allvalidmoves(board: b.Board) []b.Board {
         for (queenMoves) |move| {
             if (!s.isCheck(move, true)) {
                 boardCopy = move;
+                boardCopy.position.sidetomove = next_side;
                 moves[movecount] = boardCopy;
                 movecount += 1;
             }
@@ -835,6 +838,7 @@ pub fn allvalidmoves(board: b.Board) []b.Board {
             for (rookMoves) |move| {
                 if (!s.isCheck(move, true)) {
                     boardCopy = move;
+                    boardCopy.position.sidetomove = next_side;
                     moves[movecount] = boardCopy;
                     movecount += 1;
                 }
@@ -850,6 +854,7 @@ pub fn allvalidmoves(board: b.Board) []b.Board {
             for (bishopMoves) |move| {
                 if (!s.isCheck(move, true)) {
                     boardCopy = move;
+                    boardCopy.position.sidetomove = next_side;
                     moves[movecount] = boardCopy;
                     movecount += 1;
                 }
@@ -865,6 +870,7 @@ pub fn allvalidmoves(board: b.Board) []b.Board {
             for (knightMoves) |move| {
                 if (!s.isCheck(move, true)) {
                     boardCopy = move;
+                    boardCopy.position.sidetomove = next_side;
                     moves[movecount] = boardCopy;
                     movecount += 1;
                 }
@@ -880,6 +886,7 @@ pub fn allvalidmoves(board: b.Board) []b.Board {
             for (pawnMoves) |move| {
                 if (!s.isCheck(move, true)) {
                     boardCopy = move;
+                    boardCopy.position.sidetomove = next_side;
                     moves[movecount] = boardCopy;
                     movecount += 1;
                 }
@@ -892,6 +899,7 @@ pub fn allvalidmoves(board: b.Board) []b.Board {
             // Only allow moves that don't leave us in check
             if (!s.isCheck(move, false)) {
                 boardCopy = move;
+                boardCopy.position.sidetomove = next_side;
                 moves[movecount] = boardCopy;
                 movecount += 1;
             }
@@ -902,6 +910,7 @@ pub fn allvalidmoves(board: b.Board) []b.Board {
         for (queenMoves) |move| {
             if (!s.isCheck(move, false)) {
                 boardCopy = move;
+                boardCopy.position.sidetomove = next_side;
                 moves[movecount] = boardCopy;
                 movecount += 1;
             }
@@ -916,6 +925,7 @@ pub fn allvalidmoves(board: b.Board) []b.Board {
             for (rookMoves) |move| {
                 if (!s.isCheck(move, false)) {
                     boardCopy = move;
+                    boardCopy.position.sidetomove = next_side;
                     moves[movecount] = boardCopy;
                     movecount += 1;
                 }
@@ -931,6 +941,7 @@ pub fn allvalidmoves(board: b.Board) []b.Board {
             for (bishopMoves) |move| {
                 if (!s.isCheck(move, false)) {
                     boardCopy = move;
+                    boardCopy.position.sidetomove = next_side;
                     moves[movecount] = boardCopy;
                     movecount += 1;
                 }
@@ -946,6 +957,7 @@ pub fn allvalidmoves(board: b.Board) []b.Board {
             for (knightMoves) |move| {
                 if (!s.isCheck(move, false)) {
                     boardCopy = move;
+                    boardCopy.position.sidetomove = next_side;
                     moves[movecount] = boardCopy;
                     movecount += 1;
                 }
@@ -961,6 +973,7 @@ pub fn allvalidmoves(board: b.Board) []b.Board {
             for (pawnMoves) |move| {
                 if (!s.isCheck(move, false)) {
                     boardCopy = move;
+                    boardCopy.position.sidetomove = next_side;
                     moves[movecount] = boardCopy;
                     movecount += 1;
                 }
@@ -1284,4 +1297,28 @@ test "allvalidmoves allows capturing the checking piece" {
     }
 
     try std.testing.expect(foundCapture);
+}
+
+test "allvalidmoves flips side to move after white moves" {
+    var board = b.Board{ .position = b.Position.init() };
+    board.position.sidetomove = 0; // White to move
+
+    const moves = allvalidmoves(board);
+    try std.testing.expect(moves.len > 0);
+
+    for (moves) |move| {
+        try std.testing.expectEqual(@as(u8, 1), move.position.sidetomove);
+    }
+}
+
+test "allvalidmoves flips side to move after black moves" {
+    var board = b.Board{ .position = b.Position.init() };
+    board.position.sidetomove = 1; // Black to move
+
+    const moves = allvalidmoves(board);
+    try std.testing.expect(moves.len > 0);
+
+    for (moves) |move| {
+        try std.testing.expectEqual(@as(u8, 0), move.position.sidetomove);
+    }
 }


### PR DESCRIPTION
## Summary
- update `allvalidmoves` to set the side to move on every generated position
- add tests that confirm generated boards flip the side and that minimax scores forced mates correctly

## Testing
- zig test src/lib.zig

------
https://chatgpt.com/codex/tasks/task_e_68d1524336d08324a93518d2dc4c6ba7