### PR TITLE
Fix castling rights updates and add regression tests

### DIFF
--- a/src/moves/king.zig
+++ b/src/moves/king.zig
@@ -57,8 +57,12 @@ pub fn getValidKingMoves(piece: b.Piece, board: b.Board) []b.Board {
             var newBoard = b.Board{ .position = board.position };
             if (piece.color == 0) {
                 newBoard.position.whitepieces.King.position = king.position;
+                newBoard.position.canCastleWhiteKingside = false;
+                newBoard.position.canCastleWhiteQueenside = false;
             } else {
                 newBoard.position.blackpieces.King.position = king.position;
+                newBoard.position.canCastleBlackKingside = false;
+                newBoard.position.canCastleBlackQueenside = false;
             }
             newBoard.position.sidetomove = next_side;
             moves[possiblemoves] = newBoard;
@@ -77,8 +81,12 @@ pub fn getValidKingMoves(piece: b.Piece, board: b.Board) []b.Board {
 
                         if (piece.color == 0) {
                             newBoard.position.whitepieces.King.position = king.position;
+                            newBoard.position.canCastleWhiteKingside = false;
+                            newBoard.position.canCastleWhiteQueenside = false;
                         } else {
                             newBoard.position.blackpieces.King.position = king.position;
+                            newBoard.position.canCastleBlackKingside = false;
+                            newBoard.position.canCastleBlackQueenside = false;
                         }
                         newBoard.position.sidetomove = next_side;
                         moves[possiblemoves] = newBoard;
@@ -110,8 +118,12 @@ pub fn getValidKingMoves(piece: b.Piece, board: b.Board) []b.Board {
             var newBoard = b.Board{ .position = board.position };
             if (piece.color == 0) {
                 newBoard.position.whitepieces.King.position = king.position;
+                newBoard.position.canCastleWhiteKingside = false;
+                newBoard.position.canCastleWhiteQueenside = false;
             } else {
                 newBoard.position.blackpieces.King.position = king.position;
+                newBoard.position.canCastleBlackKingside = false;
+                newBoard.position.canCastleBlackQueenside = false;
             }
             newBoard.position.sidetomove = next_side;
             moves[possiblemoves] = newBoard;
@@ -130,8 +142,12 @@ pub fn getValidKingMoves(piece: b.Piece, board: b.Board) []b.Board {
 
                         if (piece.color == 0) {
                             newBoard.position.whitepieces.King.position = king.position;
+                            newBoard.position.canCastleWhiteKingside = false;
+                            newBoard.position.canCastleWhiteQueenside = false;
                         } else {
                             newBoard.position.blackpieces.King.position = king.position;
+                            newBoard.position.canCastleBlackKingside = false;
+                            newBoard.position.canCastleBlackQueenside = false;
                         }
                         newBoard.position.sidetomove = next_side;
                         moves[possiblemoves] = newBoard;
@@ -143,7 +159,9 @@ pub fn getValidKingMoves(piece: b.Piece, board: b.Board) []b.Board {
     }
 
     // Add castling moves for white king (kingside) if available
-    if (piece.color == 0 and board.position.canCastleWhiteKingside and piece.position == c.E1) {
+    if (piece.color == 0 and board.position.canCastleWhiteKingside and piece.position == c.E1 and
+        board.position.whitepieces.Rook[1].position == c.H1)
+    {
         // Check if squares F1 and G1 are empty
         if ((bitmap & c.F1) == 0 and (bitmap & c.G1) == 0) {
             var castledKing = piece;
@@ -154,6 +172,7 @@ pub fn getValidKingMoves(piece: b.Piece, board: b.Board) []b.Board {
             newBoard.position.whitepieces.Rook[1].position = c.F1;
             // Remove castling right
             newBoard.position.canCastleWhiteKingside = false;
+            newBoard.position.canCastleWhiteQueenside = false;
             newBoard.position.sidetomove = next_side;
             moves[possiblemoves] = newBoard;
             possiblemoves += 1;
@@ -161,7 +180,9 @@ pub fn getValidKingMoves(piece: b.Piece, board: b.Board) []b.Board {
     }
 
     // Add castling moves for black king (kingside) if available
-    if (piece.color == 1 and board.position.canCastleBlackKingside and piece.position == c.E8) {
+    if (piece.color == 1 and board.position.canCastleBlackKingside and piece.position == c.E8 and
+        board.position.blackpieces.Rook[1].position == c.H8)
+    {
         // Check if squares F8 and G8 are empty
         if ((bitmap & c.F8) == 0 and (bitmap & c.G8) == 0) {
             var castledKing = piece;
@@ -172,6 +193,7 @@ pub fn getValidKingMoves(piece: b.Piece, board: b.Board) []b.Board {
             newBoard.position.blackpieces.Rook[1].position = c.F8;
             // Remove castling right
             newBoard.position.canCastleBlackKingside = false;
+            newBoard.position.canCastleBlackQueenside = false;
             newBoard.position.sidetomove = next_side;
             moves[possiblemoves] = newBoard;
             possiblemoves += 1;
@@ -297,6 +319,98 @@ test "getValidKingMoves for black king with castling" {
         }
     }
     try std.testing.expect(castlingFound);
+}
+
+test "castling requires rook on start square" {
+    var board_with_rook = b.Board{ .position = b.Position.emptyboard() };
+    board_with_rook.position.whitepieces.King.position = c.E1;
+    board_with_rook.position.whitepieces.Rook[1].position = c.H1;
+    board_with_rook.position.canCastleWhiteKingside = true;
+
+    const moves_with_rook = getValidKingMoves(board_with_rook.position.whitepieces.King, board_with_rook);
+    var castlingFound = false;
+    for (moves_with_rook) |move| {
+        if (move.position.whitepieces.King.position == c.G1 and
+            move.position.whitepieces.Rook[1].position == c.F1)
+        {
+            castlingFound = true;
+            break;
+        }
+    }
+    try std.testing.expect(castlingFound);
+
+    var board_without_rook = board_with_rook;
+    board_without_rook.position.whitepieces.Rook[1].position = 0;
+
+    const moves_without_rook = getValidKingMoves(board_without_rook.position.whitepieces.King, board_without_rook);
+    var castlingMissing = true;
+    for (moves_without_rook) |move| {
+        if (move.position.whitepieces.King.position == c.G1 and
+            move.position.whitepieces.Rook[1].position == c.F1)
+        {
+            castlingMissing = false;
+            break;
+        }
+    }
+    try std.testing.expect(castlingMissing);
+}
+
+test "castling unavailable after king moves" {
+    var board = b.Board{ .position = b.Position.emptyboard() };
+    board.position.whitepieces.King.position = c.E1;
+    board.position.whitepieces.Rook[1].position = c.H1;
+    board.position.canCastleWhiteKingside = true;
+    board.position.canCastleWhiteQueenside = true;
+
+    const moves = getValidKingMoves(board.position.whitepieces.King, board);
+    var moved_board: ?b.Board = null;
+    for (moves) |move| {
+        if (move.position.whitepieces.King.position == c.E2) {
+            moved_board = move;
+            break;
+        }
+    }
+    try std.testing.expect(moved_board != null);
+    try std.testing.expectEqual(false, moved_board.?.position.canCastleWhiteKingside);
+    try std.testing.expectEqual(false, moved_board.?.position.canCastleWhiteQueenside);
+
+    var reset_board = moved_board.?;
+    reset_board.position.whitepieces.King.position = c.E1;
+
+    const follow_up_moves = getValidKingMoves(reset_board.position.whitepieces.King, reset_board);
+    for (follow_up_moves) |move| {
+        try std.testing.expect(move.position.whitepieces.King.position != c.G1 or
+            move.position.whitepieces.Rook[1].position != c.F1);
+    }
+}
+
+test "castling unavailable after rook moves" {
+    var board = b.Board{ .position = b.Position.emptyboard() };
+    board.position.whitepieces.King.position = c.E1;
+    board.position.whitepieces.Rook[1].position = c.H2;
+    board.position.canCastleWhiteKingside = true;
+
+    const moves = getValidKingMoves(board.position.whitepieces.King, board);
+    for (moves) |move| {
+        try std.testing.expect(move.position.whitepieces.King.position != c.G1 or
+            move.position.whitepieces.Rook[1].position != c.F1);
+    }
+}
+
+test "castling unavailable after rook capture" {
+    var board = b.Board{ .position = b.Position.emptyboard() };
+    board.position.whitepieces.King.position = c.E1;
+    board.position.whitepieces.Rook[1].position = c.H1;
+    board.position.canCastleWhiteKingside = true;
+
+    const post_capture = board_helpers.capturewhitepiece(c.H1, board);
+    try std.testing.expectEqual(false, post_capture.position.canCastleWhiteKingside);
+
+    const moves = getValidKingMoves(post_capture.position.whitepieces.King, post_capture);
+    for (moves) |move| {
+        try std.testing.expect(move.position.whitepieces.King.position != c.G1 or
+            move.position.whitepieces.Rook[1].position != c.F1);
+    }
 }
 
 test "white king moves on corner squares" {

--- a/src/moves/rook.zig
+++ b/src/moves/rook.zig
@@ -10,6 +10,7 @@ pub fn getValidRookMoves(piece: b.Piece, board: b.Board) []b.Board {
     var index: usize = 0; // Initialize with a default value
 
     const next_side: u8 = if (board.position.sidetomove == 0) 1 else 0;
+    const from_square = piece.position;
 
     // Find which rook we're moving
     if (piece.color == 0) {
@@ -61,8 +62,18 @@ pub fn getValidRookMoves(piece: b.Piece, board: b.Board) []b.Board {
                 var newBoard = b.Board{ .position = board.position };
                 if (piece.color == 0) {
                     newBoard.position.whitepieces.Rook[index].position = newpos;
+                    if (from_square == c.A1) {
+                        newBoard.position.canCastleWhiteQueenside = false;
+                    } else if (from_square == c.H1) {
+                        newBoard.position.canCastleWhiteKingside = false;
+                    }
                 } else {
                     newBoard.position.blackpieces.Rook[index].position = newpos;
+                    if (from_square == c.A8) {
+                        newBoard.position.canCastleBlackQueenside = false;
+                    } else if (from_square == c.H8) {
+                        newBoard.position.canCastleBlackKingside = false;
+                    }
                 }
                 newBoard.position.sidetomove = next_side;
                 moves[possiblemoves] = newBoard;
@@ -78,8 +89,18 @@ pub fn getValidRookMoves(piece: b.Piece, board: b.Board) []b.Board {
 
                     if (piece.color == 0) {
                         newBoard.position.whitepieces.Rook[index].position = newpos;
+                        if (from_square == c.A1) {
+                            newBoard.position.canCastleWhiteQueenside = false;
+                        } else if (from_square == c.H1) {
+                            newBoard.position.canCastleWhiteKingside = false;
+                        }
                     } else {
                         newBoard.position.blackpieces.Rook[index].position = newpos;
+                        if (from_square == c.A8) {
+                            newBoard.position.canCastleBlackQueenside = false;
+                        } else if (from_square == c.H8) {
+                            newBoard.position.canCastleBlackKingside = false;
+                        }
                     }
                     newBoard.position.sidetomove = next_side;
                     moves[possiblemoves] = newBoard;
@@ -156,4 +177,72 @@ test "ValidRookMoves for black rook at a8 in initial board" {
     // Based on our board setup, the black rook at A8 is stored in blackpieces.Rook[1]
     const moves = getValidRookMoves(board.position.blackpieces.Rook[1], board);
     try std.testing.expectEqual(moves.len, 0);
+}
+
+test "rook move clears white kingside castling" {
+    var board = b.Board{ .position = b.Position.emptyboard() };
+    board.position.whitepieces.King.position = c.E1;
+    board.position.whitepieces.Rook[1].position = c.H1;
+    board.position.canCastleWhiteKingside = true;
+
+    const moves = getValidRookMoves(board.position.whitepieces.Rook[1], board);
+    var found = false;
+    for (moves) |move| {
+        if (move.position.whitepieces.Rook[1].position == c.H2) {
+            found = true;
+            try std.testing.expectEqual(false, move.position.canCastleWhiteKingside);
+        }
+    }
+    try std.testing.expect(found);
+}
+
+test "rook move clears white queenside castling" {
+    var board = b.Board{ .position = b.Position.emptyboard() };
+    board.position.whitepieces.King.position = c.E1;
+    board.position.whitepieces.Rook[0].position = c.A1;
+    board.position.canCastleWhiteQueenside = true;
+
+    const moves = getValidRookMoves(board.position.whitepieces.Rook[0], board);
+    var found = false;
+    for (moves) |move| {
+        if (move.position.whitepieces.Rook[0].position == c.A2) {
+            found = true;
+            try std.testing.expectEqual(false, move.position.canCastleWhiteQueenside);
+        }
+    }
+    try std.testing.expect(found);
+}
+
+test "rook move clears black kingside castling" {
+    var board = b.Board{ .position = b.Position.emptyboard() };
+    board.position.blackpieces.King.position = c.E8;
+    board.position.blackpieces.Rook[1].position = c.H8;
+    board.position.canCastleBlackKingside = true;
+
+    const moves = getValidRookMoves(board.position.blackpieces.Rook[1], board);
+    var found = false;
+    for (moves) |move| {
+        if (move.position.blackpieces.Rook[1].position == c.H7) {
+            found = true;
+            try std.testing.expectEqual(false, move.position.canCastleBlackKingside);
+        }
+    }
+    try std.testing.expect(found);
+}
+
+test "rook move clears black queenside castling" {
+    var board = b.Board{ .position = b.Position.emptyboard() };
+    board.position.blackpieces.King.position = c.E8;
+    board.position.blackpieces.Rook[0].position = c.A8;
+    board.position.canCastleBlackQueenside = true;
+
+    const moves = getValidRookMoves(board.position.blackpieces.Rook[0], board);
+    var found = false;
+    for (moves) |move| {
+        if (move.position.blackpieces.Rook[0].position == c.A7) {
+            found = true;
+            try std.testing.expectEqual(false, move.position.canCastleBlackQueenside);
+        }
+    }
+    try std.testing.expect(found);
 }

--- a/src/utils/board_helpers.zig
+++ b/src/utils/board_helpers.zig
@@ -130,9 +130,19 @@ pub fn captureblackpiece(loc: u64, board: b.Board) b.Board {
             if (boardCopy.position.blackpieces.Rook[0].position == loc) {
                 boardCopy.position.blackpieces.Rook[0].position = 0;
                 piece.position = 0;
+                if (loc == c.H8) {
+                    boardCopy.position.canCastleBlackKingside = false;
+                } else if (loc == c.A8) {
+                    boardCopy.position.canCastleBlackQueenside = false;
+                }
             } else if (boardCopy.position.blackpieces.Rook[1].position == loc) {
                 boardCopy.position.blackpieces.Rook[1].position = 0;
                 piece.position = 0;
+                if (loc == c.H8) {
+                    boardCopy.position.canCastleBlackKingside = false;
+                } else if (loc == c.A8) {
+                    boardCopy.position.canCastleBlackQueenside = false;
+                }
             }
         },
         'b' => {
@@ -242,9 +252,19 @@ pub fn capturewhitepiece(loc: u64, board: b.Board) b.Board {
             if (boardCopy.position.whitepieces.Rook[0].position == loc) {
                 boardCopy.position.whitepieces.Rook[0].position = 0;
                 piece.position = 0;
+                if (loc == c.A1) {
+                    boardCopy.position.canCastleWhiteQueenside = false;
+                } else if (loc == c.H1) {
+                    boardCopy.position.canCastleWhiteKingside = false;
+                }
             } else if (boardCopy.position.whitepieces.Rook[1].position == loc) {
                 boardCopy.position.whitepieces.Rook[1].position = 0;
                 piece.position = 0;
+                if (loc == c.A1) {
+                    boardCopy.position.canCastleWhiteQueenside = false;
+                } else if (loc == c.H1) {
+                    boardCopy.position.canCastleWhiteKingside = false;
+                }
             }
         },
         'B' => {
@@ -302,4 +322,40 @@ test "capture white pawn at e2 in initial board" {
     const board_mod = @import("../board.zig");
     const newboard = capturewhitepiece(consts.E2, board_mod.Board{ .position = board_mod.Position.init() });
     try std.testing.expectEqual(newboard.position.whitepieces.Pawn[4].position, 0);
+}
+
+test "capture white rook disables kingside castling" {
+    var board = b.Board{ .position = b.Position.emptyboard() };
+    board.position.whitepieces.Rook[1].position = c.H1;
+    board.position.canCastleWhiteKingside = true;
+
+    const post_capture = capturewhitepiece(c.H1, board);
+    try std.testing.expectEqual(false, post_capture.position.canCastleWhiteKingside);
+}
+
+test "capture white rook disables queenside castling" {
+    var board = b.Board{ .position = b.Position.emptyboard() };
+    board.position.whitepieces.Rook[0].position = c.A1;
+    board.position.canCastleWhiteQueenside = true;
+
+    const post_capture = capturewhitepiece(c.A1, board);
+    try std.testing.expectEqual(false, post_capture.position.canCastleWhiteQueenside);
+}
+
+test "capture black rook disables kingside castling" {
+    var board = b.Board{ .position = b.Position.emptyboard() };
+    board.position.blackpieces.Rook[1].position = c.H8;
+    board.position.canCastleBlackKingside = true;
+
+    const post_capture = captureblackpiece(c.H8, board);
+    try std.testing.expectEqual(false, post_capture.position.canCastleBlackKingside);
+}
+
+test "capture black rook disables queenside castling" {
+    var board = b.Board{ .position = b.Position.emptyboard() };
+    board.position.blackpieces.Rook[0].position = c.A8;
+    board.position.canCastleBlackQueenside = true;
+
+    const post_capture = captureblackpiece(c.A8, board);
+    try std.testing.expectEqual(false, post_capture.position.canCastleBlackQueenside);
 }


### PR DESCRIPTION
## Summary
- disable both castle rights whenever a king move is generated and ensure the matching rook still starts on its home square before allowing castling
- clear the relevant castle flags when a rook moves off its initial square or a starting rook is captured
- add unit tests covering king moves, rook moves, and captures so castling rights drop as soon as the pieces move or are removed

## Testing
- zig build test

------
https://chatgpt.com/codex/tasks/task_e_68d169da154083249bb18df0a46baffa