### PR TITLE
Track promoted pieces separately from pawns

### DIFF
--- a/src/board.zig
+++ b/src/board.zig
@@ -17,6 +17,24 @@ pub const Piece = struct {
     index: u8 = 0, // Track which instance of this piece type this is (0-based)
 };
 
+const MaxPromotions: usize = 8;
+
+inline fn pieceWithIndex(template: Piece, index: u8) Piece {
+    var result = template;
+    result.position = 0;
+    result.index = index;
+    return result;
+}
+
+fn initPieceArray(comptime template: Piece, comptime len: usize) [len]Piece {
+    var arr: [len]Piece = undefined;
+    comptime var i: usize = 0;
+    inline while (i < len) : (i += 1) {
+        arr[i] = pieceWithIndex(template, @intCast(i));
+    }
+    return arr;
+}
+
 pub const WhiteKing: Piece = Piece{ .color = 0, .value = 255, .representation = 'K', .stdval = 255, .position = 0x0, .index = 0 };
 pub const WhiteQueen: Piece = Piece{ .color = 0, .value = 9, .representation = 'Q', .stdval = 9, .position = 0x0, .index = 0 };
 pub const WhiteRook: Piece = Piece{ .color = 0, .value = 5, .representation = 'R', .stdval = 5, .position = 0x0, .index = 0 };
@@ -38,6 +56,14 @@ const WhitePieces = struct {
     Bishop: [2]Piece = [2]Piece{ WhiteBishop, WhiteBishop },
     Knight: [2]Piece = [2]Piece{ WhiteKnight, WhiteKnight },
     Pawn: [8]Piece = [8]Piece{ WhitePawn, WhitePawn, WhitePawn, WhitePawn, WhitePawn, WhitePawn, WhitePawn, WhitePawn },
+    PromotedQueen: [MaxPromotions]Piece = initPieceArray(WhiteQueen, MaxPromotions),
+    PromotedQueenCount: u4 = 0,
+    PromotedRook: [MaxPromotions]Piece = initPieceArray(WhiteRook, MaxPromotions),
+    PromotedRookCount: u4 = 0,
+    PromotedBishop: [MaxPromotions]Piece = initPieceArray(WhiteBishop, MaxPromotions),
+    PromotedBishopCount: u4 = 0,
+    PromotedKnight: [MaxPromotions]Piece = initPieceArray(WhiteKnight, MaxPromotions),
+    PromotedKnightCount: u4 = 0,
 };
 
 const BlackPieces = struct {
@@ -47,6 +73,14 @@ const BlackPieces = struct {
     Bishop: [2]Piece = [2]Piece{ BlackBishop, BlackBishop },
     Knight: [2]Piece = [2]Piece{ BlackKnight, BlackKnight },
     Pawn: [8]Piece = [8]Piece{ BlackPawn, BlackPawn, BlackPawn, BlackPawn, BlackPawn, BlackPawn, BlackPawn, BlackPawn },
+    PromotedQueen: [MaxPromotions]Piece = initPieceArray(BlackQueen, MaxPromotions),
+    PromotedQueenCount: u4 = 0,
+    PromotedRook: [MaxPromotions]Piece = initPieceArray(BlackRook, MaxPromotions),
+    PromotedRookCount: u4 = 0,
+    PromotedBishop: [MaxPromotions]Piece = initPieceArray(BlackBishop, MaxPromotions),
+    PromotedBishopCount: u4 = 0,
+    PromotedKnight: [MaxPromotions]Piece = initPieceArray(BlackKnight, MaxPromotions),
+    PromotedKnightCount: u4 = 0,
 };
 
 pub const Position = struct {
@@ -58,6 +92,118 @@ pub const Position = struct {
     canCastleBlackQueenside: bool = false,
     enPassantSquare: u64 = 0,
     sidetomove: u8 = 0, // 0 for white, 1 for black
+
+    fn updatePieceInSide(side: anytype, original: Piece, updated: Piece) bool {
+        inline for (std.meta.fields(@TypeOf(side.*))) |field| {
+            const field_ptr = &@field(side.*, field.name);
+            const FieldType = @TypeOf(field_ptr.*);
+            if (FieldType == Piece) {
+                if (field_ptr.*.position == original.position and field_ptr.*.representation == original.representation and field_ptr.*.index == original.index) {
+                    field_ptr.* = updated;
+                    return true;
+                }
+            } else switch (@typeInfo(FieldType)) {
+                .Array => |array_info| {
+                    if (array_info.child == Piece) {
+                        inline for (0..array_info.len) |i| {
+                            if (field_ptr.*[i].position == original.position and field_ptr.*[i].representation == original.representation and field_ptr.*[i].index == original.index) {
+                                field_ptr.*[i] = updated;
+                                return true;
+                            }
+                        }
+                    }
+                },
+                else => {},
+            }
+        }
+        return false;
+    }
+
+    fn addPromotedPiece(array: *[MaxPromotions]Piece, count: *u4, piece: Piece) !void {
+        for (array.*, 0..) |entry, i| {
+            if (entry.position == 0) {
+                var stored = piece;
+                stored.index = @intCast(i);
+                array.*[i] = stored;
+                if (count.* < MaxPromotions) {
+                    count.* += 1;
+                }
+                return;
+            }
+        }
+        return error.OutOfPromotionSlots;
+    }
+
+    fn findPromotionTargets(self: *Position, color: u8, promotion: u8) struct {
+        array: *[MaxPromotions]Piece,
+        count: *u4,
+        template: Piece,
+    } {
+        const lower = std.ascii.toLower(promotion);
+        if (color == 0) {
+            return switch (lower) {
+                'q' => .{ .array = &self.whitepieces.PromotedQueen, .count = &self.whitepieces.PromotedQueenCount, .template = WhiteQueen },
+                'r' => .{ .array = &self.whitepieces.PromotedRook, .count = &self.whitepieces.PromotedRookCount, .template = WhiteRook },
+                'b' => .{ .array = &self.whitepieces.PromotedBishop, .count = &self.whitepieces.PromotedBishopCount, .template = WhiteBishop },
+                else => .{ .array = &self.whitepieces.PromotedKnight, .count = &self.whitepieces.PromotedKnightCount, .template = WhiteKnight },
+            };
+        } else {
+            return switch (lower) {
+                'q' => .{ .array = &self.blackpieces.PromotedQueen, .count = &self.blackpieces.PromotedQueenCount, .template = BlackQueen },
+                'r' => .{ .array = &self.blackpieces.PromotedRook, .count = &self.blackpieces.PromotedRookCount, .template = BlackRook },
+                'b' => .{ .array = &self.blackpieces.PromotedBishop, .count = &self.blackpieces.PromotedBishopCount, .template = BlackBishop },
+                else => .{ .array = &self.blackpieces.PromotedKnight, .count = &self.blackpieces.PromotedKnightCount, .template = BlackKnight },
+            };
+        }
+    }
+
+    pub fn updatePiece(self: *Position, original: Piece, updated: Piece) void {
+        if (original.color == 0) {
+            _ = updatePieceInSide(&self.whitepieces, original, updated);
+        } else if (original.color == 1) {
+            _ = updatePieceInSide(&self.blackpieces, original, updated);
+        }
+    }
+
+    pub fn promotePawn(self: *Position, color: u8, pawn_index: usize, promotion: u8, target_square: u64) !void {
+        const lower = std.ascii.toLower(promotion);
+        if (lower != 'q' and lower != 'r' and lower != 'b' and lower != 'n') {
+            return error.InvalidPromotionPiece;
+        }
+
+        if (color == 0) {
+            if (pawn_index >= self.whitepieces.Pawn.len) return error.InvalidPromotionPiece;
+            self.whitepieces.Pawn[pawn_index] = pieceWithIndex(WhitePawn, @intCast(pawn_index));
+        } else {
+            if (pawn_index >= self.blackpieces.Pawn.len) return error.InvalidPromotionPiece;
+            self.blackpieces.Pawn[pawn_index] = pieceWithIndex(BlackPawn, @intCast(pawn_index));
+        }
+
+        const target = self.findPromotionTargets(color, promotion);
+        var new_piece = target.template;
+        new_piece.position = target_square;
+        new_piece.color = color;
+        try addPromotedPiece(target.array, target.count, new_piece);
+        self.enPassantSquare = 0;
+    }
+    fn flipSide(pieces: anytype) void {
+        inline for (std.meta.fields(@TypeOf(pieces.*))) |field| {
+            const field_ptr = &@field(pieces.*, field.name);
+            const FieldType = @TypeOf(field_ptr.*);
+            if (FieldType == Piece) {
+                field_ptr.*.position = reverse(field_ptr.*.position);
+            } else switch (@typeInfo(FieldType)) {
+                .Array => |array_info| {
+                    if (array_info.child == Piece) {
+                        inline for (0..array_info.len) |i| {
+                            field_ptr.*[i].position = reverse(field_ptr.*[i].position);
+                        }
+                    }
+                },
+                else => {},
+            }
+        }
+    }
 
     pub fn init() Position {
         var whitepieces: WhitePieces = WhitePieces{};
@@ -139,162 +285,57 @@ pub const Position = struct {
     }
 
     pub fn flip(self: Position) Position {
-        var whitepieces: WhitePieces = self.whitepieces;
-        var blackpieces: BlackPieces = self.blackpieces;
-        whitepieces.King.position = reverse(whitepieces.King.position);
-        whitepieces.King.index = self.whitepieces.King.index;
-        whitepieces.Queen.position = reverse(whitepieces.Queen.position);
-        whitepieces.Queen.index = self.whitepieces.Queen.index;
-        whitepieces.Rook[0].position = reverse(whitepieces.Rook[0].position);
-        whitepieces.Rook[0].index = self.whitepieces.Rook[0].index;
-        whitepieces.Rook[1].position = reverse(whitepieces.Rook[1].position);
-        whitepieces.Rook[1].index = self.whitepieces.Rook[1].index;
-        whitepieces.Bishop[0].position = reverse(whitepieces.Bishop[0].position);
-        whitepieces.Bishop[0].index = self.whitepieces.Bishop[0].index;
-        whitepieces.Bishop[1].position = reverse(whitepieces.Bishop[1].position);
-        whitepieces.Bishop[1].index = self.whitepieces.Bishop[1].index;
-        whitepieces.Knight[0].position = reverse(whitepieces.Knight[0].position);
-        whitepieces.Knight[0].index = self.whitepieces.Knight[0].index;
-        whitepieces.Knight[1].position = reverse(whitepieces.Knight[1].position);
-        whitepieces.Knight[1].index = self.whitepieces.Knight[1].index;
-        whitepieces.Pawn[0].position = reverse(whitepieces.Pawn[0].position);
-        whitepieces.Pawn[0].index = self.whitepieces.Pawn[0].index;
-        whitepieces.Pawn[1].position = reverse(whitepieces.Pawn[1].position);
-        whitepieces.Pawn[1].index = self.whitepieces.Pawn[1].index;
-        whitepieces.Pawn[2].position = reverse(whitepieces.Pawn[2].position);
-        whitepieces.Pawn[2].index = self.whitepieces.Pawn[2].index;
-        whitepieces.Pawn[3].position = reverse(whitepieces.Pawn[3].position);
-        whitepieces.Pawn[3].index = self.whitepieces.Pawn[3].index;
-        whitepieces.Pawn[4].position = reverse(whitepieces.Pawn[4].position);
-        whitepieces.Pawn[4].index = self.whitepieces.Pawn[4].index;
-        whitepieces.Pawn[5].position = reverse(whitepieces.Pawn[5].position);
-        whitepieces.Pawn[5].index = self.whitepieces.Pawn[5].index;
-        whitepieces.Pawn[6].position = reverse(whitepieces.Pawn[6].position);
-        whitepieces.Pawn[6].index = self.whitepieces.Pawn[6].index;
-        whitepieces.Pawn[7].position = reverse(whitepieces.Pawn[7].position);
-        whitepieces.Pawn[7].index = self.whitepieces.Pawn[7].index;
-        blackpieces.King.position = reverse(blackpieces.King.position);
-        blackpieces.King.index = self.blackpieces.King.index;
-        blackpieces.Queen.position = reverse(blackpieces.Queen.position);
-        blackpieces.Queen.index = self.blackpieces.Queen.index;
-        blackpieces.Rook[0].position = reverse(blackpieces.Rook[0].position);
-        blackpieces.Rook[0].index = self.blackpieces.Rook[0].index;
-        blackpieces.Rook[1].position = reverse(blackpieces.Rook[1].position);
-        blackpieces.Rook[1].index = self.blackpieces.Rook[1].index;
-        blackpieces.Bishop[0].position = reverse(blackpieces.Bishop[0].position);
-        blackpieces.Bishop[0].index = self.blackpieces.Bishop[0].index;
-        blackpieces.Bishop[1].position = reverse(blackpieces.Bishop[1].position);
-        blackpieces.Bishop[1].index = self.blackpieces.Bishop[1].index;
-        blackpieces.Knight[0].position = reverse(blackpieces.Knight[0].position);
-        blackpieces.Knight[0].index = self.blackpieces.Knight[0].index;
-        blackpieces.Knight[1].position = reverse(blackpieces.Knight[1].position);
-        blackpieces.Knight[1].index = self.blackpieces.Knight[1].index;
-        blackpieces.Pawn[0].position = reverse(blackpieces.Pawn[0].position);
-        blackpieces.Pawn[0].index = self.blackpieces.Pawn[0].index;
-        blackpieces.Pawn[1].position = reverse(blackpieces.Pawn[1].position);
-        blackpieces.Pawn[1].index = self.blackpieces.Pawn[1].index;
-        blackpieces.Pawn[2].position = reverse(blackpieces.Pawn[2].position);
-        blackpieces.Pawn[2].index = self.blackpieces.Pawn[2].index;
-        blackpieces.Pawn[3].position = reverse(blackpieces.Pawn[3].position);
-        blackpieces.Pawn[3].index = self.blackpieces.Pawn[3].index;
-        blackpieces.Pawn[4].position = reverse(blackpieces.Pawn[4].position);
-        blackpieces.Pawn[4].index = self.blackpieces.Pawn[4].index;
-        blackpieces.Pawn[5].position = reverse(blackpieces.Pawn[5].position);
-        blackpieces.Pawn[5].index = self.blackpieces.Pawn[5].index;
-        blackpieces.Pawn[6].position = reverse(blackpieces.Pawn[6].position);
-        blackpieces.Pawn[6].index = self.blackpieces.Pawn[6].index;
-        blackpieces.Pawn[7].position = reverse(blackpieces.Pawn[7].position);
-        blackpieces.Pawn[7].index = self.blackpieces.Pawn[7].index;
-
-        return Position{
-            .whitepieces = whitepieces,
-            .blackpieces = blackpieces,
-            .canCastleWhiteKingside = self.canCastleWhiteKingside,
-            .canCastleWhiteQueenside = self.canCastleWhiteQueenside,
-            .canCastleBlackKingside = self.canCastleBlackKingside,
-            .canCastleBlackQueenside = self.canCastleBlackQueenside,
-            .enPassantSquare = reverse(self.enPassantSquare),
-            .sidetomove = self.sidetomove,
-        };
+        var result = self;
+        flipSide(&result.whitepieces);
+        flipSide(&result.blackpieces);
+        result.enPassantSquare = reverse(self.enPassantSquare);
+        result.sidetomove = 1 - self.sidetomove;
+        return result;
+    }
+    fn pieceAt(position: Position, mask: u64) Piece {
+        inline for (std.meta.fields(@TypeOf(position.whitepieces))) |field| {
+            const value = @field(position.whitepieces, field.name);
+            const FieldType = @TypeOf(value);
+            if (FieldType == Piece) {
+                if (value.position & mask != 0) return value;
+            } else switch (@typeInfo(FieldType)) {
+                .Array => |array_info| {
+                    if (array_info.child == Piece) {
+                        for (value) |item| {
+                            if (item.position & mask != 0) return item;
+                        }
+                    }
+                },
+                else => {},
+            }
+        }
+        inline for (std.meta.fields(@TypeOf(position.blackpieces))) |field| {
+            const value = @field(position.blackpieces, field.name);
+            const FieldType = @TypeOf(value);
+            if (FieldType == Piece) {
+                if (value.position & mask != 0) return value;
+            } else switch (@typeInfo(FieldType)) {
+                .Array => |array_info| {
+                    if (array_info.child == Piece) {
+                        for (value) |item| {
+                            if (item.position & mask != 0) return item;
+                        }
+                    }
+                },
+                else => {},
+            }
+        }
+        return Empty;
     }
 
     pub fn print(position: Position) [64]u8 {
-        var printBuffer: [64]u8 = undefined;
-        std.debug.print("\n", .{});
-        var i: u6 = 0;
+        var printBuffer = [_]u8{'.'} ** 64;
+        var i: usize = 0;
         while (i < printBuffer.len) : (i += 1) {
-            if (position.whitepieces.King.position >> i & 1 == 1) {
-                printBuffer[i] = position.whitepieces.King.representation;
-            } else if (position.whitepieces.Queen.position >> i & 1 == 1) {
-                printBuffer[i] = position.whitepieces.Queen.representation;
-            } else if (position.whitepieces.Rook[0].position >> i & 1 == 1) {
-                printBuffer[i] = position.whitepieces.Rook[0].representation;
-            } else if (position.whitepieces.Rook[1].position >> i & 1 == 1) {
-                printBuffer[i] = position.whitepieces.Rook[1].representation;
-            } else if (position.whitepieces.Bishop[0].position >> i & 1 == 1) {
-                printBuffer[i] = position.whitepieces.Bishop[0].representation;
-            } else if (position.whitepieces.Bishop[1].position >> i & 1 == 1) {
-                printBuffer[i] = position.whitepieces.Bishop[1].representation;
-            } else if (position.whitepieces.Knight[0].position >> i & 1 == 1) {
-                printBuffer[i] = position.whitepieces.Knight[0].representation;
-            } else if (position.whitepieces.Knight[1].position >> i & 1 == 1) {
-                printBuffer[i] = position.whitepieces.Knight[1].representation;
-            } else if (position.whitepieces.Pawn[0].position >> i & 1 == 1) {
-                printBuffer[i] = position.whitepieces.Pawn[0].representation;
-            } else if (position.whitepieces.Pawn[1].position >> i & 1 == 1) {
-                printBuffer[i] = position.whitepieces.Pawn[1].representation;
-            } else if (position.whitepieces.Pawn[2].position >> i & 1 == 1) {
-                printBuffer[i] = position.whitepieces.Pawn[2].representation;
-            } else if (position.whitepieces.Pawn[3].position >> i & 1 == 1) {
-                printBuffer[i] = position.whitepieces.Pawn[3].representation;
-            } else if (position.whitepieces.Pawn[4].position >> i & 1 == 1) {
-                printBuffer[i] = position.whitepieces.Pawn[4].representation;
-            } else if (position.whitepieces.Pawn[5].position >> i & 1 == 1) {
-                printBuffer[i] = position.whitepieces.Pawn[5].representation;
-            } else if (position.whitepieces.Pawn[6].position >> i & 1 == 1) {
-                printBuffer[i] = position.whitepieces.Pawn[6].representation;
-            } else if (position.whitepieces.Pawn[7].position >> i & 1 == 1) {
-                printBuffer[i] = position.whitepieces.Pawn[7].representation;
-            } else if (position.blackpieces.King.position >> i & 1 == 1) {
-                printBuffer[i] = position.blackpieces.King.representation;
-            } else if (position.blackpieces.Queen.position >> i & 1 == 1) {
-                printBuffer[i] = position.blackpieces.Queen.representation;
-            } else if (position.blackpieces.Rook[0].position >> i & 1 == 1) {
-                printBuffer[i] = position.blackpieces.Rook[0].representation;
-            } else if (position.blackpieces.Rook[1].position >> i & 1 == 1) {
-                printBuffer[i] = position.blackpieces.Rook[1].representation;
-            } else if (position.blackpieces.Bishop[0].position >> i & 1 == 1) {
-                printBuffer[i] = position.blackpieces.Bishop[0].representation;
-            } else if (position.blackpieces.Bishop[1].position >> i & 1 == 1) {
-                printBuffer[i] = position.blackpieces.Bishop[1].representation;
-            } else if (position.blackpieces.Knight[0].position >> i & 1 == 1) {
-                printBuffer[i] = position.blackpieces.Knight[0].representation;
-            } else if (position.blackpieces.Knight[1].position >> i & 1 == 1) {
-                printBuffer[i] = position.blackpieces.Knight[1].representation;
-            } else if (position.blackpieces.Pawn[0].position >> i & 1 == 1) {
-                printBuffer[i] = position.blackpieces.Pawn[0].representation;
-            } else if (position.blackpieces.Pawn[1].position >> i & 1 == 1) {
-                printBuffer[i] = position.blackpieces.Pawn[1].representation;
-            } else if (position.blackpieces.Pawn[2].position >> i & 1 == 1) {
-                printBuffer[i] = position.blackpieces.Pawn[2].representation;
-            } else if (position.blackpieces.Pawn[3].position >> i & 1 == 1) {
-                printBuffer[i] = position.blackpieces.Pawn[3].representation;
-            } else if (position.blackpieces.Pawn[4].position >> i & 1 == 1) {
-                printBuffer[i] = position.blackpieces.Pawn[4].representation;
-            } else if (position.blackpieces.Pawn[5].position >> i & 1 == 1) {
-                printBuffer[i] = position.blackpieces.Pawn[5].representation;
-            } else if (position.blackpieces.Pawn[6].position >> i & 1 == 1) {
-                printBuffer[i] = position.blackpieces.Pawn[6].representation;
-            } else if (position.blackpieces.Pawn[7].position >> i & 1 == 1) {
-                printBuffer[i] = position.blackpieces.Pawn[7].representation;
-            } else {
-                printBuffer[i] = Empty.representation;
-            }
-            if (i == BoardSize - 1) {
-                break;
-            }
+            const mask = (@as(u64, 1) << @intCast(i));
+            const piece = pieceAt(position, mask);
+            printBuffer[i] = piece.representation;
         }
-        // print the buffer in reverse order
         for (0..printBuffer.len) |index| {
             if (index % 8 == 0 and index != 0) {
                 std.debug.print("\n", .{});
@@ -369,36 +410,112 @@ pub fn parseFen(fen: []const u8) Position {
                         position.whitepieces.King.index = 0;
                     },
                     'Q' => {
-                        position.whitepieces.Queen.position |= bit;
-                        position.whitepieces.Queen.index = 0;
+                        if (position.whitepieces.Queen.position == 0) {
+                            position.whitepieces.Queen.position = bit;
+                            position.whitepieces.Queen.index = 0;
+                        } else {
+                            var placed = false;
+                            var promotedIndex: u6 = 0;
+                            while (promotedIndex < position.whitepieces.PromotedQueen.len) : (promotedIndex += 1) {
+                                if (position.whitepieces.PromotedQueen[promotedIndex].position == 0) {
+                                    position.whitepieces.PromotedQueen[promotedIndex].position = bit;
+                                    position.whitepieces.PromotedQueen[promotedIndex].index = @intCast(promotedIndex);
+                                    if (position.whitepieces.PromotedQueenCount < MaxPromotions) {
+                                        position.whitepieces.PromotedQueenCount += 1;
+                                    }
+                                    placed = true;
+                                    break;
+                                }
+                            }
+                            if (!placed) {
+                                std.debug.print("Too many white queens in FEN\n", .{});
+                            }
+                        }
                     },
                     'R' => {
+                        var placed = false;
                         var rookCount: u6 = 0;
                         while (rookCount < position.whitepieces.Rook.len) : (rookCount += 1) {
                             if (position.whitepieces.Rook[rookCount].position == 0) {
                                 position.whitepieces.Rook[rookCount].position = bit;
                                 position.whitepieces.Rook[rookCount].index = rookCount;
+                                placed = true;
                                 break;
+                            }
+                        }
+                        if (!placed) {
+                            var promotedIndex: u6 = 0;
+                            while (promotedIndex < position.whitepieces.PromotedRook.len) : (promotedIndex += 1) {
+                                if (position.whitepieces.PromotedRook[promotedIndex].position == 0) {
+                                    position.whitepieces.PromotedRook[promotedIndex].position = bit;
+                                    position.whitepieces.PromotedRook[promotedIndex].index = @intCast(promotedIndex);
+                                    if (position.whitepieces.PromotedRookCount < MaxPromotions) {
+                                        position.whitepieces.PromotedRookCount += 1;
+                                    }
+                                    placed = true;
+                                    break;
+                                }
+                            }
+                            if (!placed) {
+                                std.debug.print("Too many white rooks in FEN\n", .{});
                             }
                         }
                     },
                     'B' => {
+                        var placed = false;
                         var bishopCount: u6 = 0;
                         while (bishopCount < position.whitepieces.Bishop.len) : (bishopCount += 1) {
                             if (position.whitepieces.Bishop[bishopCount].position == 0) {
                                 position.whitepieces.Bishop[bishopCount].position = bit;
                                 position.whitepieces.Bishop[bishopCount].index = bishopCount;
+                                placed = true;
                                 break;
+                            }
+                        }
+                        if (!placed) {
+                            var promotedIndex: u6 = 0;
+                            while (promotedIndex < position.whitepieces.PromotedBishop.len) : (promotedIndex += 1) {
+                                if (position.whitepieces.PromotedBishop[promotedIndex].position == 0) {
+                                    position.whitepieces.PromotedBishop[promotedIndex].position = bit;
+                                    position.whitepieces.PromotedBishop[promotedIndex].index = @intCast(promotedIndex);
+                                    if (position.whitepieces.PromotedBishopCount < MaxPromotions) {
+                                        position.whitepieces.PromotedBishopCount += 1;
+                                    }
+                                    placed = true;
+                                    break;
+                                }
+                            }
+                            if (!placed) {
+                                std.debug.print("Too many white bishops in FEN\n", .{});
                             }
                         }
                     },
                     'N' => {
+                        var placed = false;
                         var knightCount: u6 = 0;
                         while (knightCount < position.whitepieces.Knight.len) : (knightCount += 1) {
                             if (position.whitepieces.Knight[knightCount].position == 0) {
                                 position.whitepieces.Knight[knightCount].position = bit;
                                 position.whitepieces.Knight[knightCount].index = knightCount;
+                                placed = true;
                                 break;
+                            }
+                        }
+                        if (!placed) {
+                            var promotedIndex: u6 = 0;
+                            while (promotedIndex < position.whitepieces.PromotedKnight.len) : (promotedIndex += 1) {
+                                if (position.whitepieces.PromotedKnight[promotedIndex].position == 0) {
+                                    position.whitepieces.PromotedKnight[promotedIndex].position = bit;
+                                    position.whitepieces.PromotedKnight[promotedIndex].index = @intCast(promotedIndex);
+                                    if (position.whitepieces.PromotedKnightCount < MaxPromotions) {
+                                        position.whitepieces.PromotedKnightCount += 1;
+                                    }
+                                    placed = true;
+                                    break;
+                                }
+                            }
+                            if (!placed) {
+                                std.debug.print("Too many white knights in FEN\n", .{});
                             }
                         }
                     },
@@ -417,36 +534,112 @@ pub fn parseFen(fen: []const u8) Position {
                         position.blackpieces.King.index = 0;
                     },
                     'q' => {
-                        position.blackpieces.Queen.position |= bit;
-                        position.blackpieces.Queen.index = 0;
+                        if (position.blackpieces.Queen.position == 0) {
+                            position.blackpieces.Queen.position = bit;
+                            position.blackpieces.Queen.index = 0;
+                        } else {
+                            var placed = false;
+                            var promotedIndex: u6 = 0;
+                            while (promotedIndex < position.blackpieces.PromotedQueen.len) : (promotedIndex += 1) {
+                                if (position.blackpieces.PromotedQueen[promotedIndex].position == 0) {
+                                    position.blackpieces.PromotedQueen[promotedIndex].position = bit;
+                                    position.blackpieces.PromotedQueen[promotedIndex].index = @intCast(promotedIndex);
+                                    if (position.blackpieces.PromotedQueenCount < MaxPromotions) {
+                                        position.blackpieces.PromotedQueenCount += 1;
+                                    }
+                                    placed = true;
+                                    break;
+                                }
+                            }
+                            if (!placed) {
+                                std.debug.print("Too many black queens in FEN\n", .{});
+                            }
+                        }
                     },
                     'r' => {
+                        var placed = false;
                         var rookCount: u6 = 0;
                         while (rookCount < position.blackpieces.Rook.len) : (rookCount += 1) {
                             if (position.blackpieces.Rook[rookCount].position == 0) {
                                 position.blackpieces.Rook[rookCount].position = bit;
                                 position.blackpieces.Rook[rookCount].index = rookCount;
+                                placed = true;
                                 break;
+                            }
+                        }
+                        if (!placed) {
+                            var promotedIndex: u6 = 0;
+                            while (promotedIndex < position.blackpieces.PromotedRook.len) : (promotedIndex += 1) {
+                                if (position.blackpieces.PromotedRook[promotedIndex].position == 0) {
+                                    position.blackpieces.PromotedRook[promotedIndex].position = bit;
+                                    position.blackpieces.PromotedRook[promotedIndex].index = @intCast(promotedIndex);
+                                    if (position.blackpieces.PromotedRookCount < MaxPromotions) {
+                                        position.blackpieces.PromotedRookCount += 1;
+                                    }
+                                    placed = true;
+                                    break;
+                                }
+                            }
+                            if (!placed) {
+                                std.debug.print("Too many black rooks in FEN\n", .{});
                             }
                         }
                     },
                     'b' => {
+                        var placed = false;
                         var bishopCount: u6 = 0;
                         while (bishopCount < position.blackpieces.Bishop.len) : (bishopCount += 1) {
                             if (position.blackpieces.Bishop[bishopCount].position == 0) {
                                 position.blackpieces.Bishop[bishopCount].position = bit;
                                 position.blackpieces.Bishop[bishopCount].index = bishopCount;
+                                placed = true;
                                 break;
+                            }
+                        }
+                        if (!placed) {
+                            var promotedIndex: u6 = 0;
+                            while (promotedIndex < position.blackpieces.PromotedBishop.len) : (promotedIndex += 1) {
+                                if (position.blackpieces.PromotedBishop[promotedIndex].position == 0) {
+                                    position.blackpieces.PromotedBishop[promotedIndex].position = bit;
+                                    position.blackpieces.PromotedBishop[promotedIndex].index = @intCast(promotedIndex);
+                                    if (position.blackpieces.PromotedBishopCount < MaxPromotions) {
+                                        position.blackpieces.PromotedBishopCount += 1;
+                                    }
+                                    placed = true;
+                                    break;
+                                }
+                            }
+                            if (!placed) {
+                                std.debug.print("Too many black bishops in FEN\n", .{});
                             }
                         }
                     },
                     'n' => {
+                        var placed = false;
                         var knightCount: u6 = 0;
                         while (knightCount < position.blackpieces.Knight.len) : (knightCount += 1) {
                             if (position.blackpieces.Knight[knightCount].position == 0) {
                                 position.blackpieces.Knight[knightCount].position = bit;
                                 position.blackpieces.Knight[knightCount].index = knightCount;
+                                placed = true;
                                 break;
+                            }
+                        }
+                        if (!placed) {
+                            var promotedIndex: u6 = 0;
+                            while (promotedIndex < position.blackpieces.PromotedKnight.len) : (promotedIndex += 1) {
+                                if (position.blackpieces.PromotedKnight[promotedIndex].position == 0) {
+                                    position.blackpieces.PromotedKnight[promotedIndex].position = bit;
+                                    position.blackpieces.PromotedKnight[promotedIndex].index = @intCast(promotedIndex);
+                                    if (position.blackpieces.PromotedKnightCount < MaxPromotions) {
+                                        position.blackpieces.PromotedKnightCount += 1;
+                                    }
+                                    placed = true;
+                                    break;
+                                }
+                            }
+                            if (!placed) {
+                                std.debug.print("Too many black knights in FEN\n", .{});
                             }
                         }
                     },

--- a/src/eval.zig
+++ b/src/eval.zig
@@ -30,14 +30,31 @@ pub fn evaluate(board: Board) i32 {
             score += getPiecePositionValue(knight.position, c.KNIGHT_POSITION_TABLE, true);
         }
     }
+    for (board.position.whitepieces.PromotedKnight) |knight| {
+        if (knight.position != 0) {
+            score += @as(i32, knight.stdval) * 100;
+            score += getPiecePositionValue(knight.position, c.KNIGHT_POSITION_TABLE, true);
+        }
+    }
     inline for (board.position.whitepieces.Bishop) |bishop| {
+        if (bishop.position != 0) score += @as(i32, bishop.stdval) * 100;
+    }
+    for (board.position.whitepieces.PromotedBishop) |bishop| {
         if (bishop.position != 0) score += @as(i32, bishop.stdval) * 100;
     }
     inline for (board.position.whitepieces.Rook) |rook| {
         if (rook.position != 0) score += @as(i32, rook.stdval) * 100;
     }
+    for (board.position.whitepieces.PromotedRook) |rook| {
+        if (rook.position != 0) score += @as(i32, rook.stdval) * 100;
+    }
     if (board.position.whitepieces.Queen.position != 0) {
         score += @as(i32, board.position.whitepieces.Queen.stdval) * 100;
+    }
+    for (board.position.whitepieces.PromotedQueen) |queen| {
+        if (queen.position != 0) {
+            score += @as(i32, queen.stdval) * 100;
+        }
     }
     if (board.position.whitepieces.King.position != 0) {
         score += @as(i32, board.position.whitepieces.King.stdval) * 100;
@@ -58,14 +75,31 @@ pub fn evaluate(board: Board) i32 {
             score -= getPiecePositionValue(knight.position, c.KNIGHT_POSITION_TABLE, false);
         }
     }
+    for (board.position.blackpieces.PromotedKnight) |knight| {
+        if (knight.position != 0) {
+            score -= @as(i32, knight.stdval) * 100;
+            score -= getPiecePositionValue(knight.position, c.KNIGHT_POSITION_TABLE, false);
+        }
+    }
     inline for (board.position.blackpieces.Bishop) |bishop| {
+        if (bishop.position != 0) score -= @as(i32, bishop.stdval) * 100;
+    }
+    for (board.position.blackpieces.PromotedBishop) |bishop| {
         if (bishop.position != 0) score -= @as(i32, bishop.stdval) * 100;
     }
     inline for (board.position.blackpieces.Rook) |rook| {
         if (rook.position != 0) score -= @as(i32, rook.stdval) * 100;
     }
+    for (board.position.blackpieces.PromotedRook) |rook| {
+        if (rook.position != 0) score -= @as(i32, rook.stdval) * 100;
+    }
     if (board.position.blackpieces.Queen.position != 0) {
         score -= @as(i32, board.position.blackpieces.Queen.stdval) * 100;
+    }
+    for (board.position.blackpieces.PromotedQueen) |queen| {
+        if (queen.position != 0) {
+            score -= @as(i32, queen.stdval) * 100;
+        }
     }
     if (board.position.blackpieces.King.position != 0) {
         score -= @as(i32, board.position.blackpieces.King.stdval) * 100;
@@ -270,6 +304,18 @@ fn countPieces(board: Board, white: bool) u32 {
         for (board.position.whitepieces.Rook) |rook| {
             if (rook.position != 0) count += 1;
         }
+        for (board.position.whitepieces.PromotedBishop) |bishop| {
+            if (bishop.position != 0) count += 1;
+        }
+        for (board.position.whitepieces.PromotedRook) |rook| {
+            if (rook.position != 0) count += 1;
+        }
+        for (board.position.whitepieces.PromotedKnight) |knight| {
+            if (knight.position != 0) count += 1;
+        }
+        for (board.position.whitepieces.PromotedQueen) |queen| {
+            if (queen.position != 0) count += 1;
+        }
         if (board.position.whitepieces.Queen.position != 0) count += 1;
         if (board.position.whitepieces.King.position != 0) count += 1;
     } else {
@@ -286,6 +332,18 @@ fn countPieces(board: Board, white: bool) u32 {
         for (board.position.blackpieces.Rook) |rook| {
             if (rook.position != 0) count += 1;
         }
+        for (board.position.blackpieces.PromotedBishop) |bishop| {
+            if (bishop.position != 0) count += 1;
+        }
+        for (board.position.blackpieces.PromotedRook) |rook| {
+            if (rook.position != 0) count += 1;
+        }
+        for (board.position.blackpieces.PromotedKnight) |knight| {
+            if (knight.position != 0) count += 1;
+        }
+        for (board.position.blackpieces.PromotedQueen) |queen| {
+            if (queen.position != 0) count += 1;
+        }
         if (board.position.blackpieces.Queen.position != 0) count += 1;
         if (board.position.blackpieces.King.position != 0) count += 1;
     }
@@ -298,6 +356,19 @@ test "evaluate initial position is balanced" {
     const score = evaluate(board);
     // The initial position might not be exactly 0 due to position evaluation
     try std.testing.expect(score >= -10 and score <= 10);
+}
+
+test "evaluate counts promoted pieces" {
+    var board = Board{ .position = b.Position.emptyboard() };
+    board.position.whitepieces.Pawn[0].position = c.E7;
+    const before = evaluate(board);
+
+    board.position.promotePawn(0, 0, 'Q', c.E8) catch unreachable;
+    const after = evaluate(board);
+
+    const pawn_bonus = getPiecePositionValue(c.E7, c.PAWN_POSITION_TABLE, true);
+    const expected_diff: i32 = @intCast(9 * 100 - (1 * 100 + pawn_bonus));
+    try std.testing.expectEqual(after - before, expected_diff);
 }
 
 test "evaluate position with extra white pawn" {

--- a/src/moves.zig
+++ b/src/moves.zig
@@ -543,6 +543,18 @@ pub fn allvalidmoves(board: b.Board) []b.Board {
                 movecount += 1;
             }
         }
+        for (board.position.whitepieces.PromotedQueen) |q| {
+            if (q.position == 0) continue;
+            const promotedMoves = getValidQueenMoves(q, board);
+            for (promotedMoves) |move| {
+                if (!s.isCheck(move, true)) {
+                    boardCopy = move;
+                    boardCopy.position.sidetomove = next_side;
+                    moves[movecount] = boardCopy;
+                    movecount += 1;
+                }
+            }
+        }
 
         // Rook moves
         var rookMoveCount: usize = 0;
@@ -550,6 +562,18 @@ pub fn allvalidmoves(board: b.Board) []b.Board {
             if (r.position == 0) continue;
             const rookMoves = getValidRookMoves(r, board);
             rookMoveCount += rookMoves.len;
+            for (rookMoves) |move| {
+                if (!s.isCheck(move, true)) {
+                    boardCopy = move;
+                    boardCopy.position.sidetomove = next_side;
+                    moves[movecount] = boardCopy;
+                    movecount += 1;
+                }
+            }
+        }
+        for (board.position.whitepieces.PromotedRook) |r| {
+            if (r.position == 0) continue;
+            const rookMoves = getValidRookMoves(r, board);
             for (rookMoves) |move| {
                 if (!s.isCheck(move, true)) {
                     boardCopy = move;
@@ -575,6 +599,18 @@ pub fn allvalidmoves(board: b.Board) []b.Board {
                 }
             }
         }
+        for (board.position.whitepieces.PromotedBishop) |piece| {
+            if (piece.position == 0) continue;
+            const bishopMoves = getValidBishopMoves(piece, board);
+            for (bishopMoves) |move| {
+                if (!s.isCheck(move, true)) {
+                    boardCopy = move;
+                    boardCopy.position.sidetomove = next_side;
+                    moves[movecount] = boardCopy;
+                    movecount += 1;
+                }
+            }
+        }
 
         // Knight moves
         var knightMoveCount: usize = 0;
@@ -582,6 +618,18 @@ pub fn allvalidmoves(board: b.Board) []b.Board {
             if (k.position == 0) continue;
             const knightMoves = getValidKnightMoves(k, board);
             knightMoveCount += knightMoves.len;
+            for (knightMoves) |move| {
+                if (!s.isCheck(move, true)) {
+                    boardCopy = move;
+                    boardCopy.position.sidetomove = next_side;
+                    moves[movecount] = boardCopy;
+                    movecount += 1;
+                }
+            }
+        }
+        for (board.position.whitepieces.PromotedKnight) |k| {
+            if (k.position == 0) continue;
+            const knightMoves = getValidKnightMoves(k, board);
             for (knightMoves) |move| {
                 if (!s.isCheck(move, true)) {
                     boardCopy = move;
@@ -630,6 +678,18 @@ pub fn allvalidmoves(board: b.Board) []b.Board {
                 movecount += 1;
             }
         }
+        for (board.position.blackpieces.PromotedQueen) |q| {
+            if (q.position == 0) continue;
+            const promotedMoves = getValidQueenMoves(q, board);
+            for (promotedMoves) |move| {
+                if (!s.isCheck(move, false)) {
+                    boardCopy = move;
+                    boardCopy.position.sidetomove = next_side;
+                    moves[movecount] = boardCopy;
+                    movecount += 1;
+                }
+            }
+        }
 
         // Rook moves
         var rookMoveCount: usize = 0;
@@ -637,6 +697,18 @@ pub fn allvalidmoves(board: b.Board) []b.Board {
             if (r.position == 0) continue;
             const rookMoves = getValidRookMoves(r, board);
             rookMoveCount += rookMoves.len;
+            for (rookMoves) |move| {
+                if (!s.isCheck(move, false)) {
+                    boardCopy = move;
+                    boardCopy.position.sidetomove = next_side;
+                    moves[movecount] = boardCopy;
+                    movecount += 1;
+                }
+            }
+        }
+        for (board.position.blackpieces.PromotedRook) |r| {
+            if (r.position == 0) continue;
+            const rookMoves = getValidRookMoves(r, board);
             for (rookMoves) |move| {
                 if (!s.isCheck(move, false)) {
                     boardCopy = move;
@@ -662,6 +734,18 @@ pub fn allvalidmoves(board: b.Board) []b.Board {
                 }
             }
         }
+        for (board.position.blackpieces.PromotedBishop) |piece| {
+            if (piece.position == 0) continue;
+            const bishopMoves = getValidBishopMoves(piece, board);
+            for (bishopMoves) |move| {
+                if (!s.isCheck(move, false)) {
+                    boardCopy = move;
+                    boardCopy.position.sidetomove = next_side;
+                    moves[movecount] = boardCopy;
+                    movecount += 1;
+                }
+            }
+        }
 
         // Knight moves
         var knightMoveCount: usize = 0;
@@ -669,6 +753,18 @@ pub fn allvalidmoves(board: b.Board) []b.Board {
             if (k.position == 0) continue;
             const knightMoves = getValidKnightMoves(k, board);
             knightMoveCount += knightMoves.len;
+            for (knightMoves) |move| {
+                if (!s.isCheck(move, false)) {
+                    boardCopy = move;
+                    boardCopy.position.sidetomove = next_side;
+                    moves[movecount] = boardCopy;
+                    movecount += 1;
+                }
+            }
+        }
+        for (board.position.blackpieces.PromotedKnight) |k| {
+            if (k.position == 0) continue;
+            const knightMoves = getValidKnightMoves(k, board);
             for (knightMoves) |move| {
                 if (!s.isCheck(move, false)) {
                     boardCopy = move;
@@ -761,74 +857,32 @@ pub fn applyMove(board: b.Board, move: Move) !b.Board {
 
     // Find the matching move in valid moves
     for (valid_moves) |valid_move| {
-        // Find the piece that moved by comparing board states
-        var found_piece_pos: u64 = 0;
+        const destination_piece = board_helpers.piecefromlocation(move.to, valid_move);
+        const from_square_after = board_helpers.piecefromlocation(move.from, valid_move);
 
-        // Check white pieces
-        inline for (std.meta.fields(@TypeOf(valid_move.position.whitepieces))) |field| {
-            const old_piece = @field(board.position.whitepieces, field.name);
-            const new_piece = @field(valid_move.position.whitepieces, field.name);
+        // The origin square must be empty after the move (the piece moved away)
+        if (from_square_after.position != 0) continue;
 
-            if (@TypeOf(old_piece) == b.Piece) {
-                if (old_piece.position == move.from) {
-                    found_piece_pos = new_piece.position;
-                }
-            } else if (@TypeOf(old_piece) == [2]b.Piece or @TypeOf(old_piece) == [8]b.Piece) {
-                for (old_piece, 0..) |p, i| {
-                    if (p.position == move.from) {
-                        found_piece_pos = new_piece[i].position;
-                    }
-                }
-            }
-        }
-
-        // Check black pieces if we haven't found the move
-        if (found_piece_pos == 0) {
-            inline for (std.meta.fields(@TypeOf(valid_move.position.blackpieces))) |field| {
-                const old_piece = @field(board.position.blackpieces, field.name);
-                const new_piece = @field(valid_move.position.blackpieces, field.name);
-
-                if (@TypeOf(old_piece) == b.Piece) {
-                    if (old_piece.position == move.from) {
-                        found_piece_pos = new_piece.position;
-                    }
-                } else if (@TypeOf(old_piece) == [2]b.Piece or @TypeOf(old_piece) == [8]b.Piece) {
-                    for (old_piece, 0..) |p, i| {
-                        if (p.position == move.from) {
-                            found_piece_pos = new_piece[i].position;
-                        }
-                    }
-                }
-            }
-        }
-
-        // If this valid move matches our input move, return it
-        var result = valid_move;
-        if (found_piece_pos == move.to) {
-            // Handle promotion if specified
-            if (move.promotion_piece) |promotion| {
-                // Find the pawn that was promoted and update its representation
-                if (board.position.sidetomove == 0) {
-                    // White pawn promotion
-                    for (&result.position.whitepieces.Pawn) |*p| {
-                        if (p.position == move.to) {
-                            p.representation = std.ascii.toUpper(promotion);
-                            break;
-                        }
-                    }
-                } else {
-                    // Black pawn promotion
-                    for (&result.position.blackpieces.Pawn) |*p| {
-                        if (p.position == move.to) {
-                            p.representation = promotion;
-                            break;
-                        }
-                    }
-                }
-                //  update side to move
+        // Promotion handling requires the resulting piece to match the requested promotion
+        if (move.promotion_piece) |promotion| {
+            const expected = if (board.position.sidetomove == 0)
+                std.ascii.toUpper(promotion)
+            else
+                std.ascii.toLower(promotion);
+            if (destination_piece.position == move.to and destination_piece.representation == expected) {
+                var result = valid_move;
                 result.position.sidetomove = 1 - board.position.sidetomove;
                 return result;
             }
+            continue;
+        }
+
+        // Non-promotion moves require the moving piece type/color to match the origin piece
+        if (destination_piece.position == move.to and
+            destination_piece.representation == piece.representation and
+            destination_piece.color == piece.color)
+        {
+            var result = valid_move;
             result.position.sidetomove = 1 - board.position.sidetomove;
             return result;
         }
@@ -878,8 +932,9 @@ test "applyMove pawn promotion" {
     };
 
     const new_board = try applyMove(board, move);
-    try std.testing.expectEqual(new_board.position.whitepieces.Pawn[0].position, c.E8);
-    try std.testing.expectEqual(new_board.position.whitepieces.Pawn[0].representation, 'Q');
+    try std.testing.expectEqual(new_board.position.whitepieces.Pawn[0].position, 0);
+    const promoted = board_helpers.piecefromlocation(c.E8, new_board);
+    try std.testing.expectEqual(promoted.representation, 'Q');
 }
 
 test "applyMove invalid move" {
@@ -908,6 +963,61 @@ test "applyMove castling" {
     const new_board = try applyMove(board, move);
     try std.testing.expectEqual(new_board.position.whitepieces.King.position, c.G1);
     try std.testing.expectEqual(new_board.position.whitepieces.Rook[1].position, c.F1);
+}
+
+test "promoted queen can move" {
+    var board = b.Board{ .position = b.Position.emptyboard() };
+    board.position.whitepieces.Pawn[0].position = c.E7;
+
+    const promotion_moves = pawn.getValidPawnMoves(board.position.whitepieces.Pawn[0], board);
+    var promoted_board: ?b.Board = null;
+    for (promotion_moves) |candidate| {
+        const promoted = board_helpers.piecefromlocation(c.E8, candidate);
+        if (promoted.position != 0 and promoted.representation == 'Q') {
+            promoted_board = candidate;
+            break;
+        }
+    }
+    try std.testing.expect(promoted_board != null);
+
+    const promoted_piece = board_helpers.piecefromlocation(c.E8, promoted_board.?);
+    const queen_moves = queen.getValidQueenMoves(promoted_piece, promoted_board.?);
+    var found_forward = false;
+    for (queen_moves) |candidate| {
+        if (board_helpers.piecefromlocation(c.E6, candidate).representation == 'Q') {
+            found_forward = true;
+            break;
+        }
+    }
+    try std.testing.expect(found_forward);
+}
+
+test "promoted black knight can move" {
+    var board = b.Board{ .position = b.Position.emptyboard() };
+    board.position.blackpieces.Pawn[1].position = c.B2;
+
+    const promotion_moves = pawn.getValidPawnMoves(board.position.blackpieces.Pawn[1], board);
+    var promoted_board: ?b.Board = null;
+    for (promotion_moves) |candidate| {
+        const promoted = board_helpers.piecefromlocation(c.B1, candidate);
+        if (promoted.position != 0 and promoted.representation == 'n') {
+            promoted_board = candidate;
+            break;
+        }
+    }
+    try std.testing.expect(promoted_board != null);
+
+    const promoted_piece = board_helpers.piecefromlocation(c.B1, promoted_board.?);
+    const knight_moves = knight.getValidKnightMoves(promoted_piece, promoted_board.?);
+    var found_jump = false;
+    for (knight_moves) |candidate| {
+        const piece = board_helpers.piecefromlocation(c.C3, candidate);
+        if (piece.representation == 'n') {
+            found_jump = true;
+            break;
+        }
+    }
+    try std.testing.expect(found_jump);
 }
 
 test "debug knight move sequence" {

--- a/src/moves/bishop.zig
+++ b/src/moves/bishop.zig
@@ -6,26 +6,7 @@ pub fn getValidBishopMoves(piece: b.Piece, board: b.Board) []b.Board {
     const bitmap: u64 = board_helpers.bitmapfromboard(board);
     var moves: [256]b.Board = undefined;
     var possiblemoves: usize = 0;
-    var index: usize = 0;
-
     const next_side: u8 = if (board.position.sidetomove == 0) 1 else 0;
-
-    // Find which bishop we're moving
-    if (piece.color == 0) {
-        for (board.position.whitepieces.Bishop, 0..) |item, loopidx| {
-            if (item.position == piece.position) {
-                index = loopidx;
-                break;
-            }
-        }
-    } else {
-        for (board.position.blackpieces.Bishop, 0..) |item, loopidx| {
-            if (item.position == piece.position) {
-                index = loopidx;
-                break;
-            }
-        }
-    }
 
     const row = board_helpers.rowfrombitmap(piece.position);
     const col = board_helpers.colfrombitmap(piece.position);
@@ -43,11 +24,9 @@ pub fn getValidBishopMoves(piece: b.Piece, board: b.Board) []b.Board {
         // Check if target square is empty
         if (bitmap & newpos == 0) {
             var newBoard = b.Board{ .position = board.position };
-            if (piece.color == 0) {
-                newBoard.position.whitepieces.Bishop[index].position = newpos;
-            } else {
-                newBoard.position.blackpieces.Bishop[index].position = newpos;
-            }
+            var newbishop = piece;
+            newbishop.position = newpos;
+            newBoard.position.updatePiece(piece, newbishop);
             newBoard.position.sidetomove = next_side;
             moves[possiblemoves] = newBoard;
             possiblemoves += 1;
@@ -59,11 +38,9 @@ pub fn getValidBishopMoves(piece: b.Piece, board: b.Board) []b.Board {
                     board_helpers.captureblackpiece(newpos, b.Board{ .position = board.position })
                 else
                     board_helpers.capturewhitepiece(newpos, b.Board{ .position = board.position });
-                if (piece.color == 0) {
-                    newBoard.position.whitepieces.Bishop[index].position = newpos;
-                } else {
-                    newBoard.position.blackpieces.Bishop[index].position = newpos;
-                }
+                var newbishop = piece;
+                newbishop.position = newpos;
+                newBoard.position.updatePiece(piece, newbishop);
                 newBoard.position.sidetomove = next_side;
                 moves[possiblemoves] = newBoard;
                 possiblemoves += 1;
@@ -81,11 +58,9 @@ pub fn getValidBishopMoves(piece: b.Piece, board: b.Board) []b.Board {
 
         if (bitmap & newpos == 0) {
             var newBoard = b.Board{ .position = board.position };
-            if (piece.color == 0) {
-                newBoard.position.whitepieces.Bishop[index].position = newpos;
-            } else {
-                newBoard.position.blackpieces.Bishop[index].position = newpos;
-            }
+            var newbishop = piece;
+            newbishop.position = newpos;
+            newBoard.position.updatePiece(piece, newbishop);
             newBoard.position.sidetomove = next_side;
             moves[possiblemoves] = newBoard;
             possiblemoves += 1;
@@ -96,11 +71,9 @@ pub fn getValidBishopMoves(piece: b.Piece, board: b.Board) []b.Board {
                     board_helpers.captureblackpiece(newpos, b.Board{ .position = board.position })
                 else
                     board_helpers.capturewhitepiece(newpos, b.Board{ .position = board.position });
-                if (piece.color == 0) {
-                    newBoard.position.whitepieces.Bishop[index].position = newpos;
-                } else {
-                    newBoard.position.blackpieces.Bishop[index].position = newpos;
-                }
+                var newbishop = piece;
+                newbishop.position = newpos;
+                newBoard.position.updatePiece(piece, newbishop);
                 newBoard.position.sidetomove = next_side;
                 moves[possiblemoves] = newBoard;
                 possiblemoves += 1;
@@ -118,11 +91,9 @@ pub fn getValidBishopMoves(piece: b.Piece, board: b.Board) []b.Board {
 
         if (bitmap & newpos == 0) {
             var newBoard = b.Board{ .position = board.position };
-            if (piece.color == 0) {
-                newBoard.position.whitepieces.Bishop[index].position = newpos;
-            } else {
-                newBoard.position.blackpieces.Bishop[index].position = newpos;
-            }
+            var newbishop = piece;
+            newbishop.position = newpos;
+            newBoard.position.updatePiece(piece, newbishop);
             newBoard.position.sidetomove = next_side;
             moves[possiblemoves] = newBoard;
             possiblemoves += 1;
@@ -133,11 +104,9 @@ pub fn getValidBishopMoves(piece: b.Piece, board: b.Board) []b.Board {
                     board_helpers.captureblackpiece(newpos, b.Board{ .position = board.position })
                 else
                     board_helpers.capturewhitepiece(newpos, b.Board{ .position = board.position });
-                if (piece.color == 0) {
-                    newBoard.position.whitepieces.Bishop[index].position = newpos;
-                } else {
-                    newBoard.position.blackpieces.Bishop[index].position = newpos;
-                }
+                var newbishop = piece;
+                newbishop.position = newpos;
+                newBoard.position.updatePiece(piece, newbishop);
                 newBoard.position.sidetomove = next_side;
                 moves[possiblemoves] = newBoard;
                 possiblemoves += 1;
@@ -155,11 +124,9 @@ pub fn getValidBishopMoves(piece: b.Piece, board: b.Board) []b.Board {
 
         if (bitmap & newpos == 0) {
             var newBoard = b.Board{ .position = board.position };
-            if (piece.color == 0) {
-                newBoard.position.whitepieces.Bishop[index].position = newpos;
-            } else {
-                newBoard.position.blackpieces.Bishop[index].position = newpos;
-            }
+            var newbishop = piece;
+            newbishop.position = newpos;
+            newBoard.position.updatePiece(piece, newbishop);
             newBoard.position.sidetomove = next_side;
             moves[possiblemoves] = newBoard;
             possiblemoves += 1;
@@ -170,11 +137,9 @@ pub fn getValidBishopMoves(piece: b.Piece, board: b.Board) []b.Board {
                     board_helpers.captureblackpiece(newpos, b.Board{ .position = board.position })
                 else
                     board_helpers.capturewhitepiece(newpos, b.Board{ .position = board.position });
-                if (piece.color == 0) {
-                    newBoard.position.whitepieces.Bishop[index].position = newpos;
-                } else {
-                    newBoard.position.blackpieces.Bishop[index].position = newpos;
-                }
+                var newbishop = piece;
+                newbishop.position = newpos;
+                newBoard.position.updatePiece(piece, newbishop);
                 newBoard.position.sidetomove = next_side;
                 moves[possiblemoves] = newBoard;
                 possiblemoves += 1;

--- a/src/moves/knight.zig
+++ b/src/moves/knight.zig
@@ -10,30 +10,6 @@ pub fn getValidKnightMoves(piece: b.Piece, board: b.Board) []b.Board {
 
     const next_side: u8 = if (board.position.sidetomove == 0) 1 else 0;
 
-    // Find the correct index for the knight
-    var index: u8 = 0;
-    if (piece.color == 0) {
-        // White knight
-        if (board.position.whitepieces.Knight[0].position == piece.position) {
-            index = 0;
-        } else if (board.position.whitepieces.Knight[1].position == piece.position) {
-            index = 1;
-        } else {
-            // Knight not found, return empty array
-            return moves[0..0];
-        }
-    } else {
-        // Black knight
-        if (board.position.blackpieces.Knight[0].position == piece.position) {
-            index = 0;
-        } else if (board.position.blackpieces.Knight[1].position == piece.position) {
-            index = 1;
-        } else {
-            // Knight not found, return empty array
-            return moves[0..0];
-        }
-    }
-
     // Define all possible knight move shifts
     // These represent the 8 possible L-shaped moves a knight can make
     const knightShifts = [_]struct { shift: i8, mask: u64 }{
@@ -66,11 +42,9 @@ pub fn getValidKnightMoves(piece: b.Piece, board: b.Board) []b.Board {
         if (bitmap & newpos == 0) {
             // Empty square - add move
             var newBoard = b.Board{ .position = board.position };
-            if (piece.color == 0) {
-                newBoard.position.whitepieces.Knight[index].position = newpos;
-            } else {
-                newBoard.position.blackpieces.Knight[index].position = newpos;
-            }
+            var newknight = piece;
+            newknight.position = newpos;
+            newBoard.position.updatePiece(piece, newknight);
             newBoard.position.sidetomove = next_side;
             moves[possiblemoves] = newBoard;
             possiblemoves += 1;
@@ -84,11 +58,9 @@ pub fn getValidKnightMoves(piece: b.Piece, board: b.Board) []b.Board {
                 else
                     board_helpers.capturewhitepiece(newpos, b.Board{ .position = board.position });
 
-                if (piece.color == 0) {
-                    newBoard.position.whitepieces.Knight[index].position = newpos;
-                } else {
-                    newBoard.position.blackpieces.Knight[index].position = newpos;
-                }
+                var newknight = piece;
+                newknight.position = newpos;
+                newBoard.position.updatePiece(piece, newknight);
                 newBoard.position.sidetomove = next_side;
                 moves[possiblemoves] = newBoard;
                 possiblemoves += 1;

--- a/src/moves/pawn.zig
+++ b/src/moves/pawn.zig
@@ -8,7 +8,7 @@ pub fn getValidPawnMoves(piece: b.Piece, board: b.Board) []b.Board {
     const bitmap: u64 = board_helpers.bitmapfromboard(board);
     var moves: [256]b.Board = undefined;
     var possiblemoves: u6 = 0;
-    var index: u64 = 0;
+    var index: usize = 0;
 
     const next_side: u8 = if (board.position.sidetomove == 0) 1 else 0;
 
@@ -47,26 +47,22 @@ pub fn getValidPawnMoves(piece: b.Piece, board: b.Board) []b.Board {
     }
 
     if (bitmap & oneSquareForward == 0) {
-        if ((piece.color == 0 and currentRow < 7) or (piece.color == 1 and currentRow > 2)) {
+        if ((piece.color == 0 and currentRow == 7) or (piece.color == 1 and currentRow == 2)) {
+            const promotions = if (piece.color == 0) [_]u8{ 'Q', 'R', 'B', 'N' } else [_]u8{ 'q', 'r', 'b', 'n' };
+            for (promotions) |promotion| {
+                var newBoard = b.Board{ .position = board.position };
+                newBoard.position.promotePawn(piece.color, index, promotion, oneSquareForward) catch continue;
+                newBoard.position.sidetomove = next_side;
+                moves[possiblemoves] = newBoard;
+                possiblemoves += 1;
+            }
+        } else if ((piece.color == 0 and currentRow < 7) or (piece.color == 1 and currentRow > 2)) {
             // Regular move
             var newBoard = b.Board{ .position = board.position };
             if (piece.color == 0) {
                 newBoard.position.whitepieces.Pawn[index].position = oneSquareForward;
             } else {
                 newBoard.position.blackpieces.Pawn[index].position = oneSquareForward;
-            }
-            newBoard.position.sidetomove = next_side;
-            moves[possiblemoves] = newBoard;
-            possiblemoves += 1;
-        } else if ((piece.color == 0 and currentRow == 7) or (piece.color == 1 and currentRow == 2)) {
-            // Promotion
-            var newBoard = b.Board{ .position = board.position };
-            if (piece.color == 0) {
-                newBoard.position.whitepieces.Pawn[index].position = oneSquareForward;
-                newBoard.position.whitepieces.Pawn[index].representation = 'Q';
-            } else {
-                newBoard.position.blackpieces.Pawn[index].position = oneSquareForward;
-                newBoard.position.blackpieces.Pawn[index].representation = 'q';
             }
             newBoard.position.sidetomove = next_side;
             moves[possiblemoves] = newBoard;
@@ -117,30 +113,31 @@ pub fn getValidPawnMoves(piece: b.Piece, board: b.Board) []b.Board {
         if (bitmap & leftCapture != 0) {
             const targetPiece = board_helpers.piecefromlocation(leftCapture, board);
             if (targetPiece.color != piece.color) {
-                var newBoard = if (piece.color == 0)
+                const capturedBoard = if (piece.color == 0)
                     board_helpers.captureblackpiece(leftCapture, b.Board{ .position = board.position })
                 else
                     board_helpers.capturewhitepiece(leftCapture, b.Board{ .position = board.position });
 
                 if ((piece.color == 0 and currentRow == 7) or (piece.color == 1 and currentRow == 2)) {
-                    // Promotion on capture
-                    if (piece.color == 0) {
-                        newBoard.position.whitepieces.Pawn[index].position = leftCapture;
-                        newBoard.position.whitepieces.Pawn[index].representation = 'Q';
-                    } else {
-                        newBoard.position.blackpieces.Pawn[index].position = leftCapture;
-                        newBoard.position.blackpieces.Pawn[index].representation = 'q';
+                    const promotions = if (piece.color == 0) [_]u8{ 'Q', 'R', 'B', 'N' } else [_]u8{ 'q', 'r', 'b', 'n' };
+                    for (promotions) |promotion| {
+                        var newBoard = capturedBoard;
+                        newBoard.position.promotePawn(piece.color, index, promotion, leftCapture) catch continue;
+                        newBoard.position.sidetomove = next_side;
+                        moves[possiblemoves] = newBoard;
+                        possiblemoves += 1;
                     }
                 } else {
+                    var newBoard = capturedBoard;
                     if (piece.color == 0) {
                         newBoard.position.whitepieces.Pawn[index].position = leftCapture;
                     } else {
                         newBoard.position.blackpieces.Pawn[index].position = leftCapture;
                     }
+                    newBoard.position.sidetomove = next_side;
+                    moves[possiblemoves] = newBoard;
+                    possiblemoves += 1;
                 }
-                newBoard.position.sidetomove = next_side;
-                moves[possiblemoves] = newBoard;
-                possiblemoves += 1;
             }
         } else if (leftCapture == board.position.enPassantSquare) {
             // En passant capture to the left
@@ -170,30 +167,31 @@ pub fn getValidPawnMoves(piece: b.Piece, board: b.Board) []b.Board {
         if (bitmap & rightCapture != 0) {
             const targetPiece = board_helpers.piecefromlocation(rightCapture, board);
             if (targetPiece.color != piece.color) {
-                var newBoard = if (piece.color == 0)
+                const capturedBoard = if (piece.color == 0)
                     board_helpers.captureblackpiece(rightCapture, b.Board{ .position = board.position })
                 else
                     board_helpers.capturewhitepiece(rightCapture, b.Board{ .position = board.position });
 
                 if ((piece.color == 0 and currentRow == 7) or (piece.color == 1 and currentRow == 2)) {
-                    // Promotion on capture
-                    if (piece.color == 0) {
-                        newBoard.position.whitepieces.Pawn[index].position = rightCapture;
-                        newBoard.position.whitepieces.Pawn[index].representation = 'Q';
-                    } else {
-                        newBoard.position.blackpieces.Pawn[index].position = rightCapture;
-                        newBoard.position.blackpieces.Pawn[index].representation = 'q';
+                    const promotions = if (piece.color == 0) [_]u8{ 'Q', 'R', 'B', 'N' } else [_]u8{ 'q', 'r', 'b', 'n' };
+                    for (promotions) |promotion| {
+                        var newBoard = capturedBoard;
+                        newBoard.position.promotePawn(piece.color, index, promotion, rightCapture) catch continue;
+                        newBoard.position.sidetomove = next_side;
+                        moves[possiblemoves] = newBoard;
+                        possiblemoves += 1;
                     }
                 } else {
+                    var newBoard = capturedBoard;
                     if (piece.color == 0) {
                         newBoard.position.whitepieces.Pawn[index].position = rightCapture;
                     } else {
                         newBoard.position.blackpieces.Pawn[index].position = rightCapture;
                     }
+                    newBoard.position.sidetomove = next_side;
+                    moves[possiblemoves] = newBoard;
+                    possiblemoves += 1;
                 }
-                newBoard.position.sidetomove = next_side;
-                moves[possiblemoves] = newBoard;
-                possiblemoves += 1;
             }
         } else if (rightCapture == board.position.enPassantSquare) {
             // En passant capture to the right
@@ -231,7 +229,19 @@ test "getValidPawnMoves from e7 in empty board" {
     var board = b.Board{ .position = b.Position.emptyboard() };
     board.position.whitepieces.Pawn[3].position = c.E7;
     const moves = getValidPawnMoves(board.position.whitepieces.Pawn[3], board);
-    try std.testing.expectEqual(moves.len, 1);
+    try std.testing.expectEqual(moves.len, 4);
+
+    const expected = [_]u8{ 'Q', 'R', 'B', 'N' };
+    var found = [_]bool{ false, false, false, false };
+    for (moves) |move| {
+        try std.testing.expectEqual(move.position.whitepieces.Pawn[3].position, 0);
+        const promoted = board_helpers.piecefromlocation(c.E8, move);
+        try std.testing.expect(promoted.position != 0);
+        const idx = std.mem.indexOfScalar(u8, &expected, promoted.representation);
+        try std.testing.expect(idx != null);
+        found[idx.?] = true;
+    }
+    for (found) |flag| try std.testing.expect(flag);
 }
 
 test "getValidPawnMoves for black pawn from e7 in start position" {
@@ -244,8 +254,19 @@ test "getValidPawnMoves for black pawn from e2 in empty board" {
     var board = b.Board{ .position = b.Position.emptyboard() };
     board.position.blackpieces.Pawn[3].position = c.E2;
     const moves = getValidPawnMoves(board.position.blackpieces.Pawn[3], board);
-    try std.testing.expectEqual(moves.len, 1); // One move to e1 with promotion
-    try std.testing.expectEqual(moves[0].position.blackpieces.Pawn[3].representation, 'q');
+    try std.testing.expectEqual(moves.len, 4);
+
+    const expected = [_]u8{ 'q', 'r', 'b', 'n' };
+    var found = [_]bool{ false, false, false, false };
+    for (moves) |move| {
+        try std.testing.expectEqual(move.position.blackpieces.Pawn[3].position, 0);
+        const promoted = board_helpers.piecefromlocation(c.E1, move);
+        try std.testing.expect(promoted.position != 0);
+        const idx = std.mem.indexOfScalar(u8, &expected, promoted.representation);
+        try std.testing.expect(idx != null);
+        found[idx.?] = true;
+    }
+    for (found) |flag| try std.testing.expect(flag);
 }
 
 test "getValidPawnMoves for black pawn capture" {
@@ -287,25 +308,50 @@ test "getValidPawnMoves for black pawn promotion on capture" {
     var board = b.Board{ .position = b.Position.emptyboard() };
     board.position.blackpieces.Pawn[3].position = c.E2;
     board.position.whitepieces.Pawn[2].position = c.D1;
-    const moves = getValidPawnMoves(board.position.blackpieces.Pawn[3], board);
 
-    var foundPromotionCapture = false;
+    const moves = getValidPawnMoves(board.position.blackpieces.Pawn[3], board);
+    try std.testing.expectEqual(moves.len, 8);
+
+    const expected = [_]u8{ 'q', 'r', 'b', 'n' };
+    var capture_found = [_]bool{ false, false, false, false };
+    var forward_found = [_]bool{ false, false, false, false };
     for (moves) |move| {
-        if (move.position.blackpieces.Pawn[3].position == c.D1) {
-            foundPromotionCapture = true;
+        try std.testing.expectEqual(move.position.blackpieces.Pawn[3].position, 0);
+        const target_capture = board_helpers.piecefromlocation(c.D1, move);
+        if (target_capture.position != 0 and target_capture.color == 1) {
+            const promoted = target_capture;
+            const idx = std.mem.indexOfScalar(u8, &expected, promoted.representation);
+            try std.testing.expect(idx != null);
+            capture_found[idx.?] = true;
             try std.testing.expectEqual(move.position.whitepieces.Pawn[2].position, 0);
-            try std.testing.expectEqual(move.position.blackpieces.Pawn[3].representation, 'q');
+        } else {
+            const promoted = board_helpers.piecefromlocation(c.E1, move);
+            const idx = std.mem.indexOfScalar(u8, &expected, promoted.representation);
+            try std.testing.expect(idx != null);
+            forward_found[idx.?] = true;
         }
     }
-    try std.testing.expect(foundPromotionCapture);
+    for (capture_found) |flag| try std.testing.expect(flag);
+    for (forward_found) |flag| try std.testing.expect(flag);
 }
 
 test "getValidPawnMoves promotion on reaching 8th rank" {
     var board = b.Board{ .position = b.Position.emptyboard() };
     board.position.whitepieces.Pawn[0].position = c.E7;
     const moves = getValidPawnMoves(board.position.whitepieces.Pawn[0], board);
-    try std.testing.expectEqual(moves.len, 1);
-    try std.testing.expectEqual(moves[0].position.whitepieces.Pawn[0].representation, 'Q');
+    try std.testing.expectEqual(moves.len, 4);
+
+    const expected = [_]u8{ 'Q', 'R', 'B', 'N' };
+    var found = [_]bool{ false, false, false, false };
+    for (moves) |move| {
+        try std.testing.expectEqual(move.position.whitepieces.Pawn[0].position, 0);
+        const promoted = board_helpers.piecefromlocation(c.E8, move);
+        try std.testing.expect(promoted.position != 0);
+        const idx = std.mem.indexOfScalar(u8, &expected, promoted.representation);
+        try std.testing.expect(idx != null);
+        found[idx.?] = true;
+    }
+    for (found) |flag| try std.testing.expect(flag);
 }
 
 test "getValidPawnMoves promotion on capture" {
@@ -313,15 +359,29 @@ test "getValidPawnMoves promotion on capture" {
     board.position.whitepieces.Pawn[0].position = c.E7;
     board.position.blackpieces.Pawn[0].position = c.F8;
     const moves = getValidPawnMoves(board.position.whitepieces.Pawn[0], board);
-    try std.testing.expectEqual(moves.len, 2); // One forward promotion, one capture promotion
-    var foundCapture = false;
+    try std.testing.expectEqual(moves.len, 8);
+
+    const expected = [_]u8{ 'Q', 'R', 'B', 'N' };
+    var capture_found = [_]bool{ false, false, false, false };
+    var forward_found = [_]bool{ false, false, false, false };
     for (moves) |move| {
-        if (move.position.blackpieces.Pawn[0].position == 0) {
-            foundCapture = true;
-            try std.testing.expectEqual(move.position.whitepieces.Pawn[0].representation, 'Q');
+        try std.testing.expectEqual(move.position.whitepieces.Pawn[0].position, 0);
+        const target_capture = board_helpers.piecefromlocation(c.F8, move);
+        if (target_capture.position != 0 and target_capture.color == 0) {
+            const promoted = target_capture;
+            const idx = std.mem.indexOfScalar(u8, &expected, promoted.representation);
+            try std.testing.expect(idx != null);
+            capture_found[idx.?] = true;
+            try std.testing.expectEqual(move.position.blackpieces.Pawn[0].position, 0);
+        } else {
+            const promoted = board_helpers.piecefromlocation(c.E8, move);
+            const idx = std.mem.indexOfScalar(u8, &expected, promoted.representation);
+            try std.testing.expect(idx != null);
+            forward_found[idx.?] = true;
         }
     }
-    try std.testing.expect(foundCapture);
+    for (capture_found) |flag| try std.testing.expect(flag);
+    for (forward_found) |flag| try std.testing.expect(flag);
 }
 
 test "getValidPawnMoves en passant capture" {

--- a/src/moves/queen.zig
+++ b/src/moves/queen.zig
@@ -28,26 +28,20 @@ pub fn getValidQueenMoves(piece: b.Piece, board: b.Board) []b.Board {
             newqueen.position = newpos;
             moves[possiblemoves] = b.Board{ .position = board.position };
             moves[possiblemoves].position.sidetomove = next_side;
-            if (queen_piece.color == 0) {
-                moves[possiblemoves].position.whitepieces.Queen = newqueen;
-            } else {
-                moves[possiblemoves].position.blackpieces.Queen = newqueen;
-            }
+            moves[possiblemoves].position.updatePiece(queen_piece, newqueen);
             possiblemoves += 1;
         } else {
             // Check for capture
             testpiece = board_helpers.piecefromlocation(newpos, board);
             if (testpiece.color != queen_piece.color) {
                 newqueen.position = newpos;
-                if (queen_piece.color == 0) {
-                    moves[possiblemoves] = board_helpers.captureblackpiece(newpos, b.Board{ .position = board.position });
-                    moves[possiblemoves].position.sidetomove = next_side;
-                    moves[possiblemoves].position.whitepieces.Queen = newqueen;
-                } else {
-                    moves[possiblemoves] = board_helpers.capturewhitepiece(newpos, b.Board{ .position = board.position });
-                    moves[possiblemoves].position.sidetomove = next_side;
-                    moves[possiblemoves].position.blackpieces.Queen = newqueen;
-                }
+                var newBoard = if (queen_piece.color == 0)
+                    board_helpers.captureblackpiece(newpos, b.Board{ .position = board.position })
+                else
+                    board_helpers.capturewhitepiece(newpos, b.Board{ .position = board.position });
+                newBoard.position.updatePiece(queen_piece, newqueen);
+                newBoard.position.sidetomove = next_side;
+                moves[possiblemoves] = newBoard;
                 possiblemoves += 1;
             }
             break;
@@ -65,26 +59,20 @@ pub fn getValidQueenMoves(piece: b.Piece, board: b.Board) []b.Board {
             newqueen.position = newpos;
             moves[possiblemoves] = b.Board{ .position = board.position };
             moves[possiblemoves].position.sidetomove = next_side;
-            if (queen_piece.color == 0) {
-                moves[possiblemoves].position.whitepieces.Queen = newqueen;
-            } else {
-                moves[possiblemoves].position.blackpieces.Queen = newqueen;
-            }
+            moves[possiblemoves].position.updatePiece(queen_piece, newqueen);
             possiblemoves += 1;
         } else {
             // Check for capture
             testpiece = board_helpers.piecefromlocation(newpos, board);
             if (testpiece.color != queen_piece.color) {
                 newqueen.position = newpos;
-                if (queen_piece.color == 0) {
-                    moves[possiblemoves] = board_helpers.captureblackpiece(newpos, b.Board{ .position = board.position });
-                    moves[possiblemoves].position.sidetomove = next_side;
-                    moves[possiblemoves].position.whitepieces.Queen = newqueen;
-                } else {
-                    moves[possiblemoves] = board_helpers.capturewhitepiece(newpos, b.Board{ .position = board.position });
-                    moves[possiblemoves].position.sidetomove = next_side;
-                    moves[possiblemoves].position.blackpieces.Queen = newqueen;
-                }
+                var newBoard = if (queen_piece.color == 0)
+                    board_helpers.captureblackpiece(newpos, b.Board{ .position = board.position })
+                else
+                    board_helpers.capturewhitepiece(newpos, b.Board{ .position = board.position });
+                newBoard.position.updatePiece(queen_piece, newqueen);
+                newBoard.position.sidetomove = next_side;
+                moves[possiblemoves] = newBoard;
                 possiblemoves += 1;
             }
             break;
@@ -102,26 +90,20 @@ pub fn getValidQueenMoves(piece: b.Piece, board: b.Board) []b.Board {
             newqueen.position = newpos;
             moves[possiblemoves] = b.Board{ .position = board.position };
             moves[possiblemoves].position.sidetomove = next_side;
-            if (queen_piece.color == 0) {
-                moves[possiblemoves].position.whitepieces.Queen = newqueen;
-            } else {
-                moves[possiblemoves].position.blackpieces.Queen = newqueen;
-            }
+            moves[possiblemoves].position.updatePiece(queen_piece, newqueen);
             possiblemoves += 1;
         } else {
             // Check for capture
             testpiece = board_helpers.piecefromlocation(newpos, board);
             if (testpiece.color != queen_piece.color) {
                 newqueen.position = newpos;
-                if (queen_piece.color == 0) {
-                    moves[possiblemoves] = board_helpers.captureblackpiece(newpos, b.Board{ .position = board.position });
-                    moves[possiblemoves].position.sidetomove = next_side;
-                    moves[possiblemoves].position.whitepieces.Queen = newqueen;
-                } else {
-                    moves[possiblemoves] = board_helpers.capturewhitepiece(newpos, b.Board{ .position = board.position });
-                    moves[possiblemoves].position.sidetomove = next_side;
-                    moves[possiblemoves].position.blackpieces.Queen = newqueen;
-                }
+                var newBoard = if (queen_piece.color == 0)
+                    board_helpers.captureblackpiece(newpos, b.Board{ .position = board.position })
+                else
+                    board_helpers.capturewhitepiece(newpos, b.Board{ .position = board.position });
+                newBoard.position.updatePiece(queen_piece, newqueen);
+                newBoard.position.sidetomove = next_side;
+                moves[possiblemoves] = newBoard;
                 possiblemoves += 1;
             }
             break;
@@ -139,26 +121,20 @@ pub fn getValidQueenMoves(piece: b.Piece, board: b.Board) []b.Board {
             newqueen.position = newpos;
             moves[possiblemoves] = b.Board{ .position = board.position };
             moves[possiblemoves].position.sidetomove = next_side;
-            if (queen_piece.color == 0) {
-                moves[possiblemoves].position.whitepieces.Queen = newqueen;
-            } else {
-                moves[possiblemoves].position.blackpieces.Queen = newqueen;
-            }
+            moves[possiblemoves].position.updatePiece(queen_piece, newqueen);
             possiblemoves += 1;
         } else {
             // Check for capture
             testpiece = board_helpers.piecefromlocation(newpos, board);
             if (testpiece.color != queen_piece.color) {
                 newqueen.position = newpos;
-                if (queen_piece.color == 0) {
-                    moves[possiblemoves] = board_helpers.captureblackpiece(newpos, b.Board{ .position = board.position });
-                    moves[possiblemoves].position.sidetomove = next_side;
-                    moves[possiblemoves].position.whitepieces.Queen = newqueen;
-                } else {
-                    moves[possiblemoves] = board_helpers.capturewhitepiece(newpos, b.Board{ .position = board.position });
-                    moves[possiblemoves].position.sidetomove = next_side;
-                    moves[possiblemoves].position.blackpieces.Queen = newqueen;
-                }
+                var newBoard = if (queen_piece.color == 0)
+                    board_helpers.captureblackpiece(newpos, b.Board{ .position = board.position })
+                else
+                    board_helpers.capturewhitepiece(newpos, b.Board{ .position = board.position });
+                newBoard.position.updatePiece(queen_piece, newqueen);
+                newBoard.position.sidetomove = next_side;
+                moves[possiblemoves] = newBoard;
                 possiblemoves += 1;
             }
             break;
@@ -177,26 +153,20 @@ pub fn getValidQueenMoves(piece: b.Piece, board: b.Board) []b.Board {
             newqueen.position = newpos;
             moves[possiblemoves] = b.Board{ .position = board.position };
             moves[possiblemoves].position.sidetomove = next_side;
-            if (queen_piece.color == 0) {
-                moves[possiblemoves].position.whitepieces.Queen = newqueen;
-            } else {
-                moves[possiblemoves].position.blackpieces.Queen = newqueen;
-            }
+            moves[possiblemoves].position.updatePiece(queen_piece, newqueen);
             possiblemoves += 1;
         } else {
             // Check for capture
             testpiece = board_helpers.piecefromlocation(newpos, board);
             if (testpiece.color != queen_piece.color) {
                 newqueen.position = newpos;
-                if (queen_piece.color == 0) {
-                    moves[possiblemoves] = board_helpers.captureblackpiece(newpos, b.Board{ .position = board.position });
-                    moves[possiblemoves].position.sidetomove = next_side;
-                    moves[possiblemoves].position.whitepieces.Queen = newqueen;
-                } else {
-                    moves[possiblemoves] = board_helpers.capturewhitepiece(newpos, b.Board{ .position = board.position });
-                    moves[possiblemoves].position.sidetomove = next_side;
-                    moves[possiblemoves].position.blackpieces.Queen = newqueen;
-                }
+                var newBoard = if (queen_piece.color == 0)
+                    board_helpers.captureblackpiece(newpos, b.Board{ .position = board.position })
+                else
+                    board_helpers.capturewhitepiece(newpos, b.Board{ .position = board.position });
+                newBoard.position.updatePiece(queen_piece, newqueen);
+                newBoard.position.sidetomove = next_side;
+                moves[possiblemoves] = newBoard;
                 possiblemoves += 1;
             }
             break;
@@ -214,26 +184,20 @@ pub fn getValidQueenMoves(piece: b.Piece, board: b.Board) []b.Board {
             newqueen.position = newpos;
             moves[possiblemoves] = b.Board{ .position = board.position };
             moves[possiblemoves].position.sidetomove = next_side;
-            if (queen_piece.color == 0) {
-                moves[possiblemoves].position.whitepieces.Queen = newqueen;
-            } else {
-                moves[possiblemoves].position.blackpieces.Queen = newqueen;
-            }
+            moves[possiblemoves].position.updatePiece(queen_piece, newqueen);
             possiblemoves += 1;
         } else {
             // Check for capture
             testpiece = board_helpers.piecefromlocation(newpos, board);
             if (testpiece.color != queen_piece.color) {
                 newqueen.position = newpos;
-                if (queen_piece.color == 0) {
-                    moves[possiblemoves] = board_helpers.captureblackpiece(newpos, b.Board{ .position = board.position });
-                    moves[possiblemoves].position.sidetomove = next_side;
-                    moves[possiblemoves].position.whitepieces.Queen = newqueen;
-                } else {
-                    moves[possiblemoves] = board_helpers.capturewhitepiece(newpos, b.Board{ .position = board.position });
-                    moves[possiblemoves].position.sidetomove = next_side;
-                    moves[possiblemoves].position.blackpieces.Queen = newqueen;
-                }
+                var newBoard = if (queen_piece.color == 0)
+                    board_helpers.captureblackpiece(newpos, b.Board{ .position = board.position })
+                else
+                    board_helpers.capturewhitepiece(newpos, b.Board{ .position = board.position });
+                newBoard.position.updatePiece(queen_piece, newqueen);
+                newBoard.position.sidetomove = next_side;
+                moves[possiblemoves] = newBoard;
                 possiblemoves += 1;
             }
             break;
@@ -251,26 +215,20 @@ pub fn getValidQueenMoves(piece: b.Piece, board: b.Board) []b.Board {
             newqueen.position = newpos;
             moves[possiblemoves] = b.Board{ .position = board.position };
             moves[possiblemoves].position.sidetomove = next_side;
-            if (queen_piece.color == 0) {
-                moves[possiblemoves].position.whitepieces.Queen = newqueen;
-            } else {
-                moves[possiblemoves].position.blackpieces.Queen = newqueen;
-            }
+            moves[possiblemoves].position.updatePiece(queen_piece, newqueen);
             possiblemoves += 1;
         } else {
             // Check for capture
             testpiece = board_helpers.piecefromlocation(newpos, board);
             if (testpiece.color != queen_piece.color) {
                 newqueen.position = newpos;
-                if (queen_piece.color == 0) {
-                    moves[possiblemoves] = board_helpers.captureblackpiece(newpos, b.Board{ .position = board.position });
-                    moves[possiblemoves].position.sidetomove = next_side;
-                    moves[possiblemoves].position.whitepieces.Queen = newqueen;
-                } else {
-                    moves[possiblemoves] = board_helpers.capturewhitepiece(newpos, b.Board{ .position = board.position });
-                    moves[possiblemoves].position.sidetomove = next_side;
-                    moves[possiblemoves].position.blackpieces.Queen = newqueen;
-                }
+                var newBoard = if (queen_piece.color == 0)
+                    board_helpers.captureblackpiece(newpos, b.Board{ .position = board.position })
+                else
+                    board_helpers.capturewhitepiece(newpos, b.Board{ .position = board.position });
+                newBoard.position.updatePiece(queen_piece, newqueen);
+                newBoard.position.sidetomove = next_side;
+                moves[possiblemoves] = newBoard;
                 possiblemoves += 1;
             }
             break;
@@ -287,24 +245,20 @@ pub fn getValidQueenMoves(piece: b.Piece, board: b.Board) []b.Board {
             // Empty square
             newqueen.position = newpos;
             moves[possiblemoves] = b.Board{ .position = board.position };
-            if (queen_piece.color == 0) {
-                moves[possiblemoves].position.whitepieces.Queen = newqueen;
-            } else {
-                moves[possiblemoves].position.blackpieces.Queen = newqueen;
-            }
+            moves[possiblemoves].position.updatePiece(queen_piece, newqueen);
             possiblemoves += 1;
         } else {
             // Check for capture
             testpiece = board_helpers.piecefromlocation(newpos, board);
             if (testpiece.color != queen_piece.color) {
                 newqueen.position = newpos;
-                if (queen_piece.color == 0) {
-                    moves[possiblemoves] = board_helpers.captureblackpiece(newpos, b.Board{ .position = board.position });
-                    moves[possiblemoves].position.whitepieces.Queen = newqueen;
-                } else {
-                    moves[possiblemoves] = board_helpers.capturewhitepiece(newpos, b.Board{ .position = board.position });
-                    moves[possiblemoves].position.blackpieces.Queen = newqueen;
-                }
+                var newBoard = if (queen_piece.color == 0)
+                    board_helpers.captureblackpiece(newpos, b.Board{ .position = board.position })
+                else
+                    board_helpers.capturewhitepiece(newpos, b.Board{ .position = board.position });
+                newBoard.position.updatePiece(queen_piece, newqueen);
+                newBoard.position.sidetomove = next_side;
+                moves[possiblemoves] = newBoard;
                 possiblemoves += 1;
             }
             break;

--- a/src/moves/rook.zig
+++ b/src/moves/rook.zig
@@ -7,27 +7,8 @@ pub fn getValidRookMoves(piece: b.Piece, board: b.Board) []b.Board {
     const bitmap: u64 = board_helpers.bitmapfromboard(board);
     var moves: [256]b.Board = undefined;
     var possiblemoves: usize = 0;
-    var index: usize = 0; // Initialize with a default value
-
     const next_side: u8 = if (board.position.sidetomove == 0) 1 else 0;
     const from_square = piece.position;
-
-    // Find which rook we're moving
-    if (piece.color == 0) {
-        for (board.position.whitepieces.Rook, 0..) |item, loopidx| {
-            if (item.position == piece.position) {
-                index = loopidx;
-                break;
-            }
-        }
-    } else {
-        for (board.position.blackpieces.Rook, 0..) |item, loopidx| {
-            if (item.position == piece.position) {
-                index = loopidx;
-                break;
-            }
-        }
-    }
 
     const row: u64 = board_helpers.rowfrombitmap(piece.position);
     const col: u64 = board_helpers.colfrombitmap(piece.position);
@@ -60,15 +41,16 @@ pub fn getValidRookMoves(piece: b.Piece, board: b.Board) []b.Board {
             // Check if square is empty
             if (bitmap & newpos == 0) {
                 var newBoard = b.Board{ .position = board.position };
+                var newrook = piece;
+                newrook.position = newpos;
+                newBoard.position.updatePiece(piece, newrook);
                 if (piece.color == 0) {
-                    newBoard.position.whitepieces.Rook[index].position = newpos;
                     if (from_square == c.A1) {
                         newBoard.position.canCastleWhiteQueenside = false;
                     } else if (from_square == c.H1) {
                         newBoard.position.canCastleWhiteKingside = false;
                     }
                 } else {
-                    newBoard.position.blackpieces.Rook[index].position = newpos;
                     if (from_square == c.A8) {
                         newBoard.position.canCastleBlackQueenside = false;
                     } else if (from_square == c.H8) {
@@ -82,28 +64,30 @@ pub fn getValidRookMoves(piece: b.Piece, board: b.Board) []b.Board {
                 // Square is occupied - check if it's an enemy piece
                 const targetPiece = board_helpers.piecefromlocation(newpos, board);
                 if (targetPiece.color != piece.color) {
-                    var newBoard = if (piece.color == 0)
+                    const newBoard = if (piece.color == 0)
                         board_helpers.captureblackpiece(newpos, b.Board{ .position = board.position })
                     else
                         board_helpers.capturewhitepiece(newpos, b.Board{ .position = board.position });
 
+                    var movedBoard = newBoard;
+                    var newrook = piece;
+                    newrook.position = newpos;
+                    movedBoard.position.updatePiece(piece, newrook);
                     if (piece.color == 0) {
-                        newBoard.position.whitepieces.Rook[index].position = newpos;
                         if (from_square == c.A1) {
-                            newBoard.position.canCastleWhiteQueenside = false;
+                            movedBoard.position.canCastleWhiteQueenside = false;
                         } else if (from_square == c.H1) {
-                            newBoard.position.canCastleWhiteKingside = false;
+                            movedBoard.position.canCastleWhiteKingside = false;
                         }
                     } else {
-                        newBoard.position.blackpieces.Rook[index].position = newpos;
                         if (from_square == c.A8) {
-                            newBoard.position.canCastleBlackQueenside = false;
+                            movedBoard.position.canCastleBlackQueenside = false;
                         } else if (from_square == c.H8) {
-                            newBoard.position.canCastleBlackKingside = false;
+                            movedBoard.position.canCastleBlackKingside = false;
                         }
                     }
-                    newBoard.position.sidetomove = next_side;
-                    moves[possiblemoves] = newBoard;
+                    movedBoard.position.sidetomove = next_side;
+                    moves[possiblemoves] = movedBoard;
                     possiblemoves += 1;
                 }
                 break; // Stop checking this direction after hitting any piece

--- a/src/uci/helpers.zig
+++ b/src/uci/helpers.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 const b = @import("../board.zig");
-const c = @import("../consts.zig");
+const board_helpers = @import("../utils/board_helpers.zig");
 
 /// Convert a bitboard position to algebraic notation square (e.g., "e4")
 pub fn bitboardToSquare(position: u64) [2]u8 {
@@ -22,73 +22,77 @@ pub fn moveToUci(old_board: b.Board, new_board: b.Board) [5]u8 {
     var result: [5]u8 = undefined;
     var from_pos: u64 = 0;
     var to_pos: u64 = 0;
-    var is_promotion = false;
+
     inline for (std.meta.fields(@TypeOf(old_board.position.whitepieces))) |field| {
         const old_piece = @field(old_board.position.whitepieces, field.name);
         const new_piece = @field(new_board.position.whitepieces, field.name);
-        if (@TypeOf(old_piece) == b.Piece) {
+        const FieldType = @TypeOf(old_piece);
+        if (FieldType == b.Piece) {
             if (old_piece.position != new_piece.position) {
                 if (old_piece.position != 0) from_pos = old_piece.position;
-                if (new_piece.position != 0) {
-                    to_pos = new_piece.position;
-                    if (field.name[0] == 'P' and new_piece.representation == 'Q') {
-                        is_promotion = true;
-                    }
-                }
+                if (new_piece.position != 0) to_pos = new_piece.position;
             }
-        } else if (@TypeOf(old_piece) == [2]b.Piece or @TypeOf(old_piece) == [8]b.Piece) {
-            for (old_piece, 0..) |piece, i| {
-                if (piece.position != new_piece[i].position) {
-                    if (piece.position != 0) from_pos = piece.position;
-                    if (new_piece[i].position != 0) {
-                        to_pos = new_piece[i].position;
-                        if (field.name[0] == 'P' and new_piece[i].representation == 'Q') {
-                            is_promotion = true;
+        } else switch (@typeInfo(FieldType)) {
+            .Array => |array_info| {
+                if (array_info.child == b.Piece) {
+                    for (old_piece, 0..) |piece, i| {
+                        if (piece.position != new_piece[i].position) {
+                            if (piece.position != 0) from_pos = piece.position;
+                            if (new_piece[i].position != 0) to_pos = new_piece[i].position;
                         }
                     }
                 }
-            }
+            },
+            else => {},
         }
     }
+
     if (from_pos == 0) {
         inline for (std.meta.fields(@TypeOf(old_board.position.blackpieces))) |field| {
             const old_piece = @field(old_board.position.blackpieces, field.name);
             const new_piece = @field(new_board.position.blackpieces, field.name);
-            if (@TypeOf(old_piece) == b.Piece) {
+            const FieldType = @TypeOf(old_piece);
+            if (FieldType == b.Piece) {
                 if (old_piece.position != new_piece.position) {
                     if (old_piece.position != 0) from_pos = old_piece.position;
-                    if (new_piece.position != 0) {
-                        to_pos = new_piece.position;
-                        if (field.name[0] == 'P' and new_piece.representation == 'q') {
-                            is_promotion = true;
-                        }
-                    }
+                    if (new_piece.position != 0) to_pos = new_piece.position;
                 }
-            } else if (@TypeOf(old_piece) == [2]b.Piece or @TypeOf(old_piece) == [8]b.Piece) {
-                for (old_piece, 0..) |piece, i| {
-                    if (piece.position != new_piece[i].position) {
-                        if (piece.position != 0) from_pos = piece.position;
-                        if (new_piece[i].position != 0) {
-                            to_pos = new_piece[i].position;
-                            if (field.name[0] == 'P' and new_piece[i].representation == 'q') {
-                                is_promotion = true;
+            } else switch (@typeInfo(FieldType)) {
+                .Array => |array_info| {
+                    if (array_info.child == b.Piece) {
+                        for (old_piece, 0..) |piece, i| {
+                            if (piece.position != new_piece[i].position) {
+                                if (piece.position != 0) from_pos = piece.position;
+                                if (new_piece[i].position != 0) to_pos = new_piece[i].position;
                             }
                         }
                     }
-                }
+                },
+                else => {},
             }
         }
     }
+
     const from_square = bitboardToSquare(from_pos);
     const to_square = bitboardToSquare(to_pos);
     result[0] = from_square[0];
     result[1] = from_square[1];
     result[2] = to_square[0];
     result[3] = to_square[1];
-    if (is_promotion) {
-        result[4] = 'q';
-    } else {
-        result[4] = 0;
+
+    var promotion_char: u8 = 0;
+    if (from_pos != 0 and to_pos != 0) {
+        const from_piece = board_helpers.piecefromlocation(from_pos, old_board);
+        const to_piece = board_helpers.piecefromlocation(to_pos, new_board);
+        if (from_piece.representation == 'P' or from_piece.representation == 'p') {
+            const lower = std.ascii.toLower(to_piece.representation);
+            switch (lower) {
+                'q', 'r', 'b', 'n' => promotion_char = lower,
+                else => {},
+            }
+        }
     }
+
+    result[4] = promotion_char;
     return result;
 }

--- a/src/utils/board_helpers.zig
+++ b/src/utils/board_helpers.zig
@@ -7,24 +7,36 @@ const std = @import("std");
 
 pub fn bitmapfromboard(board: b.Board) u64 {
     var bitmap: u64 = 0;
-    const cpiece = b.Piece{ .color = 0, .value = 1, .representation = 'P', .stdval = 1, .position = 0 };
-    _ = cpiece;
-    inline for (std.meta.fields(@TypeOf(board.position.whitepieces))) |piece| {
-        if (@TypeOf(@as(piece.type, @field(board.position.whitepieces, piece.name))) == (b.Piece)) {
-            bitmap |= (@as(piece.type, @field(board.position.whitepieces, piece.name))).position;
-        } else if (@TypeOf(@as(piece.type, @field(board.position.whitepieces, piece.name))) == ([2]b.Piece) or @TypeOf(@as(piece.type, @field(board.position.whitepieces, piece.name))) == ([8]b.Piece)) {
-            for (@as(piece.type, @field(board.position.whitepieces, piece.name))) |item| {
-                bitmap |= item.position;
-            }
+    inline for (std.meta.fields(@TypeOf(board.position.whitepieces))) |field| {
+        const value = @field(board.position.whitepieces, field.name);
+        const FieldType = @TypeOf(value);
+        if (FieldType == b.Piece) {
+            bitmap |= value.position;
+        } else switch (@typeInfo(FieldType)) {
+            .Array => |array_info| {
+                if (array_info.child == b.Piece) {
+                    for (value) |item| {
+                        bitmap |= item.position;
+                    }
+                }
+            },
+            else => {},
         }
     }
-    inline for (std.meta.fields(@TypeOf(board.position.blackpieces))) |piece| {
-        if (@TypeOf(@as(piece.type, @field(board.position.blackpieces, piece.name))) == (b.Piece)) {
-            bitmap |= (@as(piece.type, @field(board.position.blackpieces, piece.name))).position;
-        } else if (@TypeOf(@as(piece.type, @field(board.position.blackpieces, piece.name))) == ([2]b.Piece) or @TypeOf(@as(piece.type, @field(board.position.blackpieces, piece.name))) == ([8]b.Piece)) {
-            for (@as(piece.type, @field(board.position.blackpieces, piece.name))) |item| {
-                bitmap |= item.position;
-            }
+    inline for (std.meta.fields(@TypeOf(board.position.blackpieces))) |field| {
+        const value = @field(board.position.blackpieces, field.name);
+        const FieldType = @TypeOf(value);
+        if (FieldType == b.Piece) {
+            bitmap |= value.position;
+        } else switch (@typeInfo(FieldType)) {
+            .Array => |array_info| {
+                if (array_info.child == b.Piece) {
+                    for (value) |item| {
+                        bitmap |= item.position;
+                    }
+                }
+            },
+            else => {},
         }
     }
     return bitmap;
@@ -39,30 +51,36 @@ test "bitmap of initial board" {
 
 pub fn piecefromlocation(location: u64, board: b.Board) b.Piece {
     // iterate through all pieces of each colour to find which piece position matches the location
-    inline for (std.meta.fields(@TypeOf(board.position.whitepieces))) |piece| {
-        if (@TypeOf(@as(piece.type, @field(board.position.whitepieces, piece.name))) == (b.Piece)) {
-            if ((@as(piece.type, @field(board.position.whitepieces, piece.name))).position == location) {
-                return (@as(piece.type, @field(board.position.whitepieces, piece.name)));
-            }
-        } else if (@TypeOf(@as(piece.type, @field(board.position.whitepieces, piece.name))) == ([2]b.Piece) or @TypeOf(@as(piece.type, @field(board.position.whitepieces, piece.name))) == ([8]b.Piece)) {
-            for (@as(piece.type, @field(board.position.whitepieces, piece.name))) |item| {
-                if (item.position == location) {
-                    return item;
+    inline for (std.meta.fields(@TypeOf(board.position.whitepieces))) |field| {
+        const value = @field(board.position.whitepieces, field.name);
+        const FieldType = @TypeOf(value);
+        if (FieldType == b.Piece) {
+            if (value.position == location) return value;
+        } else switch (@typeInfo(FieldType)) {
+            .Array => |array_info| {
+                if (array_info.child == b.Piece) {
+                    for (value) |item| {
+                        if (item.position == location) return item;
+                    }
                 }
-            }
+            },
+            else => {},
         }
     }
-    inline for (std.meta.fields(@TypeOf(board.position.blackpieces))) |piece| {
-        if (@TypeOf(@as(piece.type, @field(board.position.blackpieces, piece.name))) == (b.Piece)) {
-            if ((@as(piece.type, @field(board.position.blackpieces, piece.name))).position == location) {
-                return (@as(piece.type, @field(board.position.blackpieces, piece.name)));
-            }
-        } else if (@TypeOf(@as(piece.type, @field(board.position.blackpieces, piece.name))) == ([2]b.Piece) or @TypeOf(@as(piece.type, @field(board.position.blackpieces, piece.name))) == ([8]b.Piece)) {
-            for (@as(piece.type, @field(board.position.blackpieces, piece.name))) |item| {
-                if (item.position == location) {
-                    return item;
+    inline for (std.meta.fields(@TypeOf(board.position.blackpieces))) |field| {
+        const value = @field(board.position.blackpieces, field.name);
+        const FieldType = @TypeOf(value);
+        if (FieldType == b.Piece) {
+            if (value.position == location) return value;
+        } else switch (@typeInfo(FieldType)) {
+            .Array => |array_info| {
+                if (array_info.child == b.Piece) {
+                    for (value) |item| {
+                        if (item.position == location) return item;
+                    }
                 }
-            }
+            },
+            else => {},
         }
     }
     return b.Piece{ .color = 0, .value = 0, .representation = '.', .stdval = 0, .position = 0 };
@@ -123,8 +141,21 @@ pub fn captureblackpiece(loc: u64, board: b.Board) b.Board {
             piece.position = 0;
         },
         'q' => {
-            boardCopy.position.blackpieces.Queen.position = 0;
-            piece.position = 0;
+            if (boardCopy.position.blackpieces.Queen.position == loc) {
+                boardCopy.position.blackpieces.Queen.position = 0;
+                piece.position = 0;
+            } else {
+                for (&boardCopy.position.blackpieces.PromotedQueen) |*promoted| {
+                    if (promoted.position == loc) {
+                        promoted.position = 0;
+                        piece.position = 0;
+                        if (boardCopy.position.blackpieces.PromotedQueenCount > 0) {
+                            boardCopy.position.blackpieces.PromotedQueenCount -= 1;
+                        }
+                        break;
+                    }
+                }
+            }
         },
         'r' => {
             if (boardCopy.position.blackpieces.Rook[0].position == loc) {
@@ -143,6 +174,17 @@ pub fn captureblackpiece(loc: u64, board: b.Board) b.Board {
                 } else if (loc == c.A8) {
                     boardCopy.position.canCastleBlackQueenside = false;
                 }
+            } else {
+                for (&boardCopy.position.blackpieces.PromotedRook) |*promoted| {
+                    if (promoted.position == loc) {
+                        promoted.position = 0;
+                        piece.position = 0;
+                        if (boardCopy.position.blackpieces.PromotedRookCount > 0) {
+                            boardCopy.position.blackpieces.PromotedRookCount -= 1;
+                        }
+                        break;
+                    }
+                }
             }
         },
         'b' => {
@@ -152,6 +194,17 @@ pub fn captureblackpiece(loc: u64, board: b.Board) b.Board {
             } else if (boardCopy.position.blackpieces.Bishop[1].position == loc) {
                 boardCopy.position.blackpieces.Bishop[1].position = 0;
                 piece.position = 0;
+            } else {
+                for (&boardCopy.position.blackpieces.PromotedBishop) |*promoted| {
+                    if (promoted.position == loc) {
+                        promoted.position = 0;
+                        piece.position = 0;
+                        if (boardCopy.position.blackpieces.PromotedBishopCount > 0) {
+                            boardCopy.position.blackpieces.PromotedBishopCount -= 1;
+                        }
+                        break;
+                    }
+                }
             }
         },
         'n' => {
@@ -161,6 +214,17 @@ pub fn captureblackpiece(loc: u64, board: b.Board) b.Board {
             } else if (boardCopy.position.blackpieces.Knight[1].position == loc) {
                 boardCopy.position.blackpieces.Knight[1].position = 0;
                 piece.position = 0;
+            } else {
+                for (&boardCopy.position.blackpieces.PromotedKnight) |*promoted| {
+                    if (promoted.position == loc) {
+                        promoted.position = 0;
+                        piece.position = 0;
+                        if (boardCopy.position.blackpieces.PromotedKnightCount > 0) {
+                            boardCopy.position.blackpieces.PromotedKnightCount -= 1;
+                        }
+                        break;
+                    }
+                }
             }
         },
         'p' => {
@@ -245,8 +309,21 @@ pub fn capturewhitepiece(loc: u64, board: b.Board) b.Board {
             piece.position = 0;
         },
         'Q' => {
-            boardCopy.position.whitepieces.Queen.position = 0;
-            piece.position = 0;
+            if (boardCopy.position.whitepieces.Queen.position == loc) {
+                boardCopy.position.whitepieces.Queen.position = 0;
+                piece.position = 0;
+            } else {
+                for (&boardCopy.position.whitepieces.PromotedQueen) |*promoted| {
+                    if (promoted.position == loc) {
+                        promoted.position = 0;
+                        piece.position = 0;
+                        if (boardCopy.position.whitepieces.PromotedQueenCount > 0) {
+                            boardCopy.position.whitepieces.PromotedQueenCount -= 1;
+                        }
+                        break;
+                    }
+                }
+            }
         },
         'R' => {
             if (boardCopy.position.whitepieces.Rook[0].position == loc) {
@@ -265,6 +342,17 @@ pub fn capturewhitepiece(loc: u64, board: b.Board) b.Board {
                 } else if (loc == c.H1) {
                     boardCopy.position.canCastleWhiteKingside = false;
                 }
+            } else {
+                for (&boardCopy.position.whitepieces.PromotedRook) |*promoted| {
+                    if (promoted.position == loc) {
+                        promoted.position = 0;
+                        piece.position = 0;
+                        if (boardCopy.position.whitepieces.PromotedRookCount > 0) {
+                            boardCopy.position.whitepieces.PromotedRookCount -= 1;
+                        }
+                        break;
+                    }
+                }
             }
         },
         'B' => {
@@ -274,6 +362,17 @@ pub fn capturewhitepiece(loc: u64, board: b.Board) b.Board {
             } else if (boardCopy.position.whitepieces.Bishop[1].position == loc) {
                 boardCopy.position.whitepieces.Bishop[1].position = 0;
                 piece.position = 0;
+            } else {
+                for (&boardCopy.position.whitepieces.PromotedBishop) |*promoted| {
+                    if (promoted.position == loc) {
+                        promoted.position = 0;
+                        piece.position = 0;
+                        if (boardCopy.position.whitepieces.PromotedBishopCount > 0) {
+                            boardCopy.position.whitepieces.PromotedBishopCount -= 1;
+                        }
+                        break;
+                    }
+                }
             }
         },
         'N' => {
@@ -283,6 +382,17 @@ pub fn capturewhitepiece(loc: u64, board: b.Board) b.Board {
             } else if (boardCopy.position.whitepieces.Knight[1].position == loc) {
                 boardCopy.position.whitepieces.Knight[1].position = 0;
                 piece.position = 0;
+            } else {
+                for (&boardCopy.position.whitepieces.PromotedKnight) |*promoted| {
+                    if (promoted.position == loc) {
+                        promoted.position = 0;
+                        piece.position = 0;
+                        if (boardCopy.position.whitepieces.PromotedKnightCount > 0) {
+                            boardCopy.position.whitepieces.PromotedKnightCount -= 1;
+                        }
+                        break;
+                    }
+                }
             }
         },
         'P' => {
@@ -358,4 +468,15 @@ test "capture black rook disables queenside castling" {
 
     const post_capture = captureblackpiece(c.A8, board);
     try std.testing.expectEqual(false, post_capture.position.canCastleBlackQueenside);
+}
+
+test "capture promoted white queen clears slot" {
+    var board = b.Board{ .position = b.Position.emptyboard() };
+    board.position.promotePawn(0, 0, 'Q', c.E8) catch unreachable;
+    try std.testing.expectEqual(@as(u4, 1), board.position.whitepieces.PromotedQueenCount);
+
+    const post_capture = capturewhitepiece(c.E8, board);
+    try std.testing.expectEqual(@as(u4, 0), post_capture.position.whitepieces.PromotedQueenCount);
+    const piece = piecefromlocation(c.E8, post_capture);
+    try std.testing.expectEqual(piece.position, 0);
 }


### PR DESCRIPTION
## Summary
- extend the board representation with dedicated promoted-piece arrays and helpers, including promotion updates and printing
- update move generation, move application, and capture helpers to create, iterate, and remove promoted pieces correctly
- teach evaluation, UCI conversion, and tests to account for promoted material, including new promotion movement/evaluation coverage

## Testing
- `zig build test`


------
https://chatgpt.com/codex/tasks/task_e_68d16e5caa048324bdb0b94c2a47ac6c