### PR TITLE
Handle promoted pieces and add promotion tests

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -8,34 +8,34 @@ pub fn build(b: *std.Build) void {
     // Create executable
     const exe = b.addExecutable(.{
         .name = "play",
-        .root_source_file = .{ .cwd_relative = "src/uci.zig" },
+        .root_source_file = .{ .path = "src/uci.zig" },
         .target = target,
         .optimize = optimize,
     });
 
     // Add module dependencies
     const board_module = b.addModule("board", .{
-        .root_source_file = .{ .cwd_relative = "src/board.zig" },
+        .source_file = .{ .path = "src/board.zig" },
     });
     const consts_module = b.addModule("consts", .{
-        .root_source_file = .{ .cwd_relative = "src/consts.zig" },
+        .source_file = .{ .path = "src/consts.zig" },
     });
     const moves_module = b.addModule("moves", .{
-        .root_source_file = .{ .cwd_relative = "src/moves.zig" },
+        .source_file = .{ .path = "src/moves.zig" },
     });
     const state_module = b.addModule("state", .{
-        .root_source_file = .{ .cwd_relative = "src/state.zig" },
+        .source_file = .{ .path = "src/state.zig" },
     });
     const eval_module = b.addModule("eval", .{
-        .root_source_file = .{ .cwd_relative = "src/eval.zig" },
+        .source_file = .{ .path = "src/eval.zig" },
     });
 
     // Add module dependencies to executable using the new syntax
-    exe.root_module.addImport("board", board_module);
-    exe.root_module.addImport("consts", consts_module);
-    exe.root_module.addImport("moves", moves_module);
-    exe.root_module.addImport("state", state_module);
-    exe.root_module.addImport("eval", eval_module);
+    exe.addModule("board", board_module);
+    exe.addModule("consts", consts_module);
+    exe.addModule("moves", moves_module);
+    exe.addModule("state", state_module);
+    exe.addModule("eval", eval_module);
 
     // Install the executable in the prefix
     b.installArtifact(exe);
@@ -53,17 +53,17 @@ pub fn build(b: *std.Build) void {
 
     // Add tests
     const unit_tests = b.addTest(.{
-        .root_source_file = .{ .cwd_relative = "src/lib.zig" },
+        .root_source_file = .{ .path = "src/lib.zig" },
         .target = target,
         .optimize = optimize,
     });
 
     // Add module dependencies to tests using the new syntax
-    unit_tests.root_module.addImport("board", board_module);
-    unit_tests.root_module.addImport("consts", consts_module);
-    unit_tests.root_module.addImport("moves", moves_module);
-    unit_tests.root_module.addImport("state", state_module);
-    unit_tests.root_module.addImport("eval", eval_module);
+    unit_tests.addModule("board", board_module);
+    unit_tests.addModule("consts", consts_module);
+    unit_tests.addModule("moves", moves_module);
+    unit_tests.addModule("state", state_module);
+    unit_tests.addModule("eval", eval_module);
 
     const run_unit_tests = b.addRunArtifact(unit_tests);
 

--- a/src/eval.zig
+++ b/src/eval.zig
@@ -30,14 +30,31 @@ pub fn evaluate(board: Board) i32 {
             score += getPiecePositionValue(knight.position, c.KNIGHT_POSITION_TABLE, true);
         }
     }
+    inline for (board.position.whitepieces.Promoted.Knight) |knight| {
+        if (knight.position != 0 and knight.is_promoted) {
+            score += @as(i32, knight.stdval) * 100;
+            score += getPiecePositionValue(knight.position, c.KNIGHT_POSITION_TABLE, true);
+        }
+    }
     inline for (board.position.whitepieces.Bishop) |bishop| {
         if (bishop.position != 0) score += @as(i32, bishop.stdval) * 100;
+    }
+    inline for (board.position.whitepieces.Promoted.Bishop) |bishop| {
+        if (bishop.position != 0 and bishop.is_promoted) score += @as(i32, bishop.stdval) * 100;
     }
     inline for (board.position.whitepieces.Rook) |rook| {
         if (rook.position != 0) score += @as(i32, rook.stdval) * 100;
     }
+    inline for (board.position.whitepieces.Promoted.Rook) |rook| {
+        if (rook.position != 0 and rook.is_promoted) score += @as(i32, rook.stdval) * 100;
+    }
     if (board.position.whitepieces.Queen.position != 0) {
         score += @as(i32, board.position.whitepieces.Queen.stdval) * 100;
+    }
+    inline for (board.position.whitepieces.Promoted.Queen) |queen| {
+        if (queen.position != 0 and queen.is_promoted) {
+            score += @as(i32, queen.stdval) * 100;
+        }
     }
     if (board.position.whitepieces.King.position != 0) {
         score += @as(i32, board.position.whitepieces.King.stdval) * 100;
@@ -58,14 +75,31 @@ pub fn evaluate(board: Board) i32 {
             score -= getPiecePositionValue(knight.position, c.KNIGHT_POSITION_TABLE, false);
         }
     }
+    inline for (board.position.blackpieces.Promoted.Knight) |knight| {
+        if (knight.position != 0 and knight.is_promoted) {
+            score -= @as(i32, knight.stdval) * 100;
+            score -= getPiecePositionValue(knight.position, c.KNIGHT_POSITION_TABLE, false);
+        }
+    }
     inline for (board.position.blackpieces.Bishop) |bishop| {
         if (bishop.position != 0) score -= @as(i32, bishop.stdval) * 100;
+    }
+    inline for (board.position.blackpieces.Promoted.Bishop) |bishop| {
+        if (bishop.position != 0 and bishop.is_promoted) score -= @as(i32, bishop.stdval) * 100;
     }
     inline for (board.position.blackpieces.Rook) |rook| {
         if (rook.position != 0) score -= @as(i32, rook.stdval) * 100;
     }
+    inline for (board.position.blackpieces.Promoted.Rook) |rook| {
+        if (rook.position != 0 and rook.is_promoted) score -= @as(i32, rook.stdval) * 100;
+    }
     if (board.position.blackpieces.Queen.position != 0) {
         score -= @as(i32, board.position.blackpieces.Queen.stdval) * 100;
+    }
+    inline for (board.position.blackpieces.Promoted.Queen) |queen| {
+        if (queen.position != 0 and queen.is_promoted) {
+            score -= @as(i32, queen.stdval) * 100;
+        }
     }
     if (board.position.blackpieces.King.position != 0) {
         score -= @as(i32, board.position.blackpieces.King.stdval) * 100;
@@ -317,6 +351,17 @@ test "evaluate position with extra white queen" {
     board.position = pos;
     const score = evaluate(board);
     try std.testing.expect(score >= 900); // Queen value is at least 900
+}
+
+test "evaluate counts promoted pieces" {
+    var board = Board{ .position = b.Position.emptyboard() };
+    board.position.whitepieces.King.position = c.E1;
+    board.position.blackpieces.King.position = c.E8;
+    board.position.clearPawnSlot(0, 0);
+    board.position.addPromotedPiece(0, 'q', c.A7);
+
+    const score = evaluate(board);
+    try std.testing.expectEqual(@as(i32, 900), score);
 }
 
 test "evaluate position with missing white king" {

--- a/src/moves.zig
+++ b/src/moves.zig
@@ -544,10 +544,37 @@ pub fn allvalidmoves(board: b.Board) []b.Board {
             }
         }
 
+        for (board.position.whitepieces.Promoted.Queen) |q| {
+            if (q.position == 0 or !q.is_promoted) continue;
+            const promotedMoves = getValidQueenMoves(q, board);
+            for (promotedMoves) |move| {
+                if (!s.isCheck(move, true)) {
+                    boardCopy = move;
+                    boardCopy.position.sidetomove = next_side;
+                    moves[movecount] = boardCopy;
+                    movecount += 1;
+                }
+            }
+        }
+
         // Rook moves
         var rookMoveCount: usize = 0;
         for (board.position.whitepieces.Rook) |r| {
             if (r.position == 0) continue;
+            const rookMoves = getValidRookMoves(r, board);
+            rookMoveCount += rookMoves.len;
+            for (rookMoves) |move| {
+                if (!s.isCheck(move, true)) {
+                    boardCopy = move;
+                    boardCopy.position.sidetomove = next_side;
+                    moves[movecount] = boardCopy;
+                    movecount += 1;
+                }
+            }
+        }
+
+        for (board.position.whitepieces.Promoted.Rook) |r| {
+            if (r.position == 0 or !r.is_promoted) continue;
             const rookMoves = getValidRookMoves(r, board);
             rookMoveCount += rookMoves.len;
             for (rookMoves) |move| {
@@ -576,10 +603,38 @@ pub fn allvalidmoves(board: b.Board) []b.Board {
             }
         }
 
+        for (board.position.whitepieces.Promoted.Bishop) |piece| {
+            if (piece.position == 0 or !piece.is_promoted) continue;
+            const bishopMoves = getValidBishopMoves(piece, board);
+            bishopMoveCount += bishopMoves.len;
+            for (bishopMoves) |move| {
+                if (!s.isCheck(move, true)) {
+                    boardCopy = move;
+                    boardCopy.position.sidetomove = next_side;
+                    moves[movecount] = boardCopy;
+                    movecount += 1;
+                }
+            }
+        }
+
         // Knight moves
         var knightMoveCount: usize = 0;
         for (board.position.whitepieces.Knight) |k| {
             if (k.position == 0) continue;
+            const knightMoves = getValidKnightMoves(k, board);
+            knightMoveCount += knightMoves.len;
+            for (knightMoves) |move| {
+                if (!s.isCheck(move, true)) {
+                    boardCopy = move;
+                    boardCopy.position.sidetomove = next_side;
+                    moves[movecount] = boardCopy;
+                    movecount += 1;
+                }
+            }
+        }
+
+        for (board.position.whitepieces.Promoted.Knight) |k| {
+            if (k.position == 0 or !k.is_promoted) continue;
             const knightMoves = getValidKnightMoves(k, board);
             knightMoveCount += knightMoves.len;
             for (knightMoves) |move| {
@@ -631,10 +686,37 @@ pub fn allvalidmoves(board: b.Board) []b.Board {
             }
         }
 
+        for (board.position.blackpieces.Promoted.Queen) |q| {
+            if (q.position == 0 or !q.is_promoted) continue;
+            const promotedMoves = getValidQueenMoves(q, board);
+            for (promotedMoves) |move| {
+                if (!s.isCheck(move, false)) {
+                    boardCopy = move;
+                    boardCopy.position.sidetomove = next_side;
+                    moves[movecount] = boardCopy;
+                    movecount += 1;
+                }
+            }
+        }
+
         // Rook moves
         var rookMoveCount: usize = 0;
         for (board.position.blackpieces.Rook) |r| {
             if (r.position == 0) continue;
+            const rookMoves = getValidRookMoves(r, board);
+            rookMoveCount += rookMoves.len;
+            for (rookMoves) |move| {
+                if (!s.isCheck(move, false)) {
+                    boardCopy = move;
+                    boardCopy.position.sidetomove = next_side;
+                    moves[movecount] = boardCopy;
+                    movecount += 1;
+                }
+            }
+        }
+
+        for (board.position.blackpieces.Promoted.Rook) |r| {
+            if (r.position == 0 or !r.is_promoted) continue;
             const rookMoves = getValidRookMoves(r, board);
             rookMoveCount += rookMoves.len;
             for (rookMoves) |move| {
@@ -663,10 +745,38 @@ pub fn allvalidmoves(board: b.Board) []b.Board {
             }
         }
 
+        for (board.position.blackpieces.Promoted.Bishop) |piece| {
+            if (piece.position == 0 or !piece.is_promoted) continue;
+            const bishopMoves = getValidBishopMoves(piece, board);
+            bishopMoveCount += bishopMoves.len;
+            for (bishopMoves) |move| {
+                if (!s.isCheck(move, false)) {
+                    boardCopy = move;
+                    boardCopy.position.sidetomove = next_side;
+                    moves[movecount] = boardCopy;
+                    movecount += 1;
+                }
+            }
+        }
+
         // Knight moves
         var knightMoveCount: usize = 0;
         for (board.position.blackpieces.Knight) |k| {
             if (k.position == 0) continue;
+            const knightMoves = getValidKnightMoves(k, board);
+            knightMoveCount += knightMoves.len;
+            for (knightMoves) |move| {
+                if (!s.isCheck(move, false)) {
+                    boardCopy = move;
+                    boardCopy.position.sidetomove = next_side;
+                    moves[movecount] = boardCopy;
+                    movecount += 1;
+                }
+            }
+        }
+
+        for (board.position.blackpieces.Promoted.Knight) |k| {
+            if (k.position == 0 or !k.is_promoted) continue;
             const knightMoves = getValidKnightMoves(k, board);
             knightMoveCount += knightMoves.len;
             for (knightMoves) |move| {
@@ -761,77 +871,37 @@ pub fn applyMove(board: b.Board, move: Move) !b.Board {
 
     // Find the matching move in valid moves
     for (valid_moves) |valid_move| {
-        // Find the piece that moved by comparing board states
-        var found_piece_pos: u64 = 0;
+        const source_after = piecefromlocation(move.from, valid_move);
+        if (source_after.position != 0) {
+            continue;
+        }
 
-        // Check white pieces
-        inline for (std.meta.fields(@TypeOf(valid_move.position.whitepieces))) |field| {
-            const old_piece = @field(board.position.whitepieces, field.name);
-            const new_piece = @field(valid_move.position.whitepieces, field.name);
+        const destination_piece = piecefromlocation(move.to, valid_move);
+        if (destination_piece.position == 0 or destination_piece.color != piece.color) {
+            continue;
+        }
 
-            if (@TypeOf(old_piece) == b.Piece) {
-                if (old_piece.position == move.from) {
-                    found_piece_pos = new_piece.position;
-                }
-            } else if (@TypeOf(old_piece) == [2]b.Piece or @TypeOf(old_piece) == [8]b.Piece) {
-                for (old_piece, 0..) |p, i| {
-                    if (p.position == move.from) {
-                        found_piece_pos = new_piece[i].position;
-                    }
-                }
+        if (move.promotion_piece) |promotion| {
+            const lower = std.ascii.toLower(promotion);
+            const expected = if (piece.color == 0)
+                std.ascii.toUpper(lower)
+            else
+                lower;
+            if (destination_piece.representation != expected or !destination_piece.is_promoted) {
+                continue;
+            }
+        } else {
+            if (destination_piece.representation != piece.representation) {
+                continue;
+            }
+            if ((piece.representation == 'P' or piece.representation == 'p') and destination_piece.is_promoted) {
+                continue;
             }
         }
 
-        // Check black pieces if we haven't found the move
-        if (found_piece_pos == 0) {
-            inline for (std.meta.fields(@TypeOf(valid_move.position.blackpieces))) |field| {
-                const old_piece = @field(board.position.blackpieces, field.name);
-                const new_piece = @field(valid_move.position.blackpieces, field.name);
-
-                if (@TypeOf(old_piece) == b.Piece) {
-                    if (old_piece.position == move.from) {
-                        found_piece_pos = new_piece.position;
-                    }
-                } else if (@TypeOf(old_piece) == [2]b.Piece or @TypeOf(old_piece) == [8]b.Piece) {
-                    for (old_piece, 0..) |p, i| {
-                        if (p.position == move.from) {
-                            found_piece_pos = new_piece[i].position;
-                        }
-                    }
-                }
-            }
-        }
-
-        // If this valid move matches our input move, return it
         var result = valid_move;
-        if (found_piece_pos == move.to) {
-            // Handle promotion if specified
-            if (move.promotion_piece) |promotion| {
-                // Find the pawn that was promoted and update its representation
-                if (board.position.sidetomove == 0) {
-                    // White pawn promotion
-                    for (&result.position.whitepieces.Pawn) |*p| {
-                        if (p.position == move.to) {
-                            p.representation = std.ascii.toUpper(promotion);
-                            break;
-                        }
-                    }
-                } else {
-                    // Black pawn promotion
-                    for (&result.position.blackpieces.Pawn) |*p| {
-                        if (p.position == move.to) {
-                            p.representation = promotion;
-                            break;
-                        }
-                    }
-                }
-                //  update side to move
-                result.position.sidetomove = 1 - board.position.sidetomove;
-                return result;
-            }
-            result.position.sidetomove = 1 - board.position.sidetomove;
-            return result;
-        }
+        result.position.sidetomove = 1 - board.position.sidetomove;
+        return result;
     }
 
     return error.InvalidMove;
@@ -878,8 +948,54 @@ test "applyMove pawn promotion" {
     };
 
     const new_board = try applyMove(board, move);
-    try std.testing.expectEqual(new_board.position.whitepieces.Pawn[0].position, c.E8);
-    try std.testing.expectEqual(new_board.position.whitepieces.Pawn[0].representation, 'Q');
+    try std.testing.expectEqual(new_board.position.whitepieces.Pawn[0].position, 0);
+    const promoted = piecefromlocation(c.E8, new_board);
+    try std.testing.expectEqual(promoted.representation, 'Q');
+    try std.testing.expect(promoted.is_promoted);
+}
+
+test "applyMove requires promotion piece" {
+    var board = b.Board{ .position = b.Position.emptyboard() };
+    board.position.whitepieces.Pawn[0].position = c.E7;
+
+    const move = Move{
+        .from = c.E7,
+        .to = c.E8,
+        .promotion_piece = null,
+    };
+
+    try std.testing.expectError(error.InvalidMove, applyMove(board, move));
+}
+
+test "promoted queen generates moves" {
+    var board = b.Board{ .position = b.Position.emptyboard() };
+    board.position.whitepieces.Pawn[0].position = c.A7;
+
+    const promotion = Move{
+        .from = c.A7,
+        .to = c.A8,
+        .promotion_piece = 'q',
+    };
+
+    var promoted_board = try applyMove(board, promotion);
+    promoted_board.position.sidetomove = 0; // Make it white's turn for move generation
+
+    const promoted_piece = piecefromlocation(c.A8, promoted_board);
+    try std.testing.expect(promoted_piece.is_promoted);
+    try std.testing.expectEqual(promoted_piece.representation, 'Q');
+
+    const queen_moves = getValidQueenMoves(promoted_piece, promoted_board);
+    try std.testing.expect(queen_moves.len > 0);
+
+    var can_move = false;
+    for (queen_moves) |candidate| {
+        const moved_piece = piecefromlocation(c.A7, candidate);
+        if (moved_piece.is_promoted and moved_piece.representation == 'Q') {
+            can_move = true;
+            break;
+        }
+    }
+    try std.testing.expect(can_move);
 }
 
 test "applyMove invalid move" {

--- a/src/moves/bishop.zig
+++ b/src/moves/bishop.zig
@@ -1,34 +1,55 @@
+const std = @import("std");
 const b = @import("../board.zig");
 const c = @import("../consts.zig");
 const board_helpers = @import("../utils/board_helpers.zig");
+
+fn placeBishop(board: *b.Board, piece: b.Piece) void {
+    var updated = piece;
+    const idx: usize = @intCast(piece.index);
+    if (piece.color == 0) {
+        if (piece.is_promoted) {
+            board.position.whitepieces.Promoted.Bishop[idx] = updated;
+        } else {
+            board.position.whitepieces.Bishop[idx] = updated;
+        }
+    } else {
+        if (piece.is_promoted) {
+            board.position.blackpieces.Promoted.Bishop[idx] = updated;
+        } else {
+            board.position.blackpieces.Bishop[idx] = updated;
+        }
+    }
+}
+
+fn resolveBaseBishopIndex(piece: b.Piece, board: b.Board) usize {
+    const collection = if (piece.color == 0)
+        board.position.whitepieces.Bishop
+    else
+        board.position.blackpieces.Bishop;
+
+    for (collection, 0..) |stored, idx| {
+        if (stored.position == piece.position) {
+            return idx;
+        }
+    }
+
+    return 0;
+}
 
 pub fn getValidBishopMoves(piece: b.Piece, board: b.Board) []b.Board {
     const bitmap: u64 = board_helpers.bitmapfromboard(board);
     var moves: [256]b.Board = undefined;
     var possiblemoves: usize = 0;
-    var index: usize = 0;
 
     const next_side: u8 = if (board.position.sidetomove == 0) 1 else 0;
 
-    // Find which bishop we're moving
-    if (piece.color == 0) {
-        for (board.position.whitepieces.Bishop, 0..) |item, loopidx| {
-            if (item.position == piece.position) {
-                index = loopidx;
-                break;
-            }
-        }
-    } else {
-        for (board.position.blackpieces.Bishop, 0..) |item, loopidx| {
-            if (item.position == piece.position) {
-                index = loopidx;
-                break;
-            }
-        }
-    }
-
     const row = board_helpers.rowfrombitmap(piece.position);
     const col = board_helpers.colfrombitmap(piece.position);
+
+    const resolved_index: usize = if (piece.is_promoted)
+        @intCast(piece.index)
+    else
+        resolveBaseBishopIndex(piece, board);
 
     // Bishop moves along diagonals
     const bishopshifts = [7]u6{ 1, 2, 3, 4, 5, 6, 7 };
@@ -43,11 +64,10 @@ pub fn getValidBishopMoves(piece: b.Piece, board: b.Board) []b.Board {
         // Check if target square is empty
         if (bitmap & newpos == 0) {
             var newBoard = b.Board{ .position = board.position };
-            if (piece.color == 0) {
-                newBoard.position.whitepieces.Bishop[index].position = newpos;
-            } else {
-                newBoard.position.blackpieces.Bishop[index].position = newpos;
-            }
+            var moved = piece;
+            moved.position = newpos;
+            moved.index = @intCast(resolved_index);
+            placeBishop(&newBoard, moved);
             newBoard.position.sidetomove = next_side;
             moves[possiblemoves] = newBoard;
             possiblemoves += 1;
@@ -59,11 +79,10 @@ pub fn getValidBishopMoves(piece: b.Piece, board: b.Board) []b.Board {
                     board_helpers.captureblackpiece(newpos, b.Board{ .position = board.position })
                 else
                     board_helpers.capturewhitepiece(newpos, b.Board{ .position = board.position });
-                if (piece.color == 0) {
-                    newBoard.position.whitepieces.Bishop[index].position = newpos;
-                } else {
-                    newBoard.position.blackpieces.Bishop[index].position = newpos;
-                }
+                var moved = piece;
+                moved.position = newpos;
+                moved.index = @intCast(resolved_index);
+                placeBishop(&newBoard, moved);
                 newBoard.position.sidetomove = next_side;
                 moves[possiblemoves] = newBoard;
                 possiblemoves += 1;
@@ -81,11 +100,10 @@ pub fn getValidBishopMoves(piece: b.Piece, board: b.Board) []b.Board {
 
         if (bitmap & newpos == 0) {
             var newBoard = b.Board{ .position = board.position };
-            if (piece.color == 0) {
-                newBoard.position.whitepieces.Bishop[index].position = newpos;
-            } else {
-                newBoard.position.blackpieces.Bishop[index].position = newpos;
-            }
+            var moved = piece;
+            moved.position = newpos;
+            moved.index = @intCast(resolved_index);
+            placeBishop(&newBoard, moved);
             newBoard.position.sidetomove = next_side;
             moves[possiblemoves] = newBoard;
             possiblemoves += 1;
@@ -96,11 +114,10 @@ pub fn getValidBishopMoves(piece: b.Piece, board: b.Board) []b.Board {
                     board_helpers.captureblackpiece(newpos, b.Board{ .position = board.position })
                 else
                     board_helpers.capturewhitepiece(newpos, b.Board{ .position = board.position });
-                if (piece.color == 0) {
-                    newBoard.position.whitepieces.Bishop[index].position = newpos;
-                } else {
-                    newBoard.position.blackpieces.Bishop[index].position = newpos;
-                }
+                var moved = piece;
+                moved.position = newpos;
+                moved.index = @intCast(resolved_index);
+                placeBishop(&newBoard, moved);
                 newBoard.position.sidetomove = next_side;
                 moves[possiblemoves] = newBoard;
                 possiblemoves += 1;
@@ -118,11 +135,10 @@ pub fn getValidBishopMoves(piece: b.Piece, board: b.Board) []b.Board {
 
         if (bitmap & newpos == 0) {
             var newBoard = b.Board{ .position = board.position };
-            if (piece.color == 0) {
-                newBoard.position.whitepieces.Bishop[index].position = newpos;
-            } else {
-                newBoard.position.blackpieces.Bishop[index].position = newpos;
-            }
+            var moved = piece;
+            moved.position = newpos;
+            moved.index = @intCast(resolved_index);
+            placeBishop(&newBoard, moved);
             newBoard.position.sidetomove = next_side;
             moves[possiblemoves] = newBoard;
             possiblemoves += 1;
@@ -133,11 +149,10 @@ pub fn getValidBishopMoves(piece: b.Piece, board: b.Board) []b.Board {
                     board_helpers.captureblackpiece(newpos, b.Board{ .position = board.position })
                 else
                     board_helpers.capturewhitepiece(newpos, b.Board{ .position = board.position });
-                if (piece.color == 0) {
-                    newBoard.position.whitepieces.Bishop[index].position = newpos;
-                } else {
-                    newBoard.position.blackpieces.Bishop[index].position = newpos;
-                }
+                var moved = piece;
+                moved.position = newpos;
+                moved.index = @intCast(resolved_index);
+                placeBishop(&newBoard, moved);
                 newBoard.position.sidetomove = next_side;
                 moves[possiblemoves] = newBoard;
                 possiblemoves += 1;
@@ -155,11 +170,9 @@ pub fn getValidBishopMoves(piece: b.Piece, board: b.Board) []b.Board {
 
         if (bitmap & newpos == 0) {
             var newBoard = b.Board{ .position = board.position };
-            if (piece.color == 0) {
-                newBoard.position.whitepieces.Bishop[index].position = newpos;
-            } else {
-                newBoard.position.blackpieces.Bishop[index].position = newpos;
-            }
+            var moved = piece;
+            moved.position = newpos;
+            placeBishop(&newBoard, moved);
             newBoard.position.sidetomove = next_side;
             moves[possiblemoves] = newBoard;
             possiblemoves += 1;
@@ -170,11 +183,9 @@ pub fn getValidBishopMoves(piece: b.Piece, board: b.Board) []b.Board {
                     board_helpers.captureblackpiece(newpos, b.Board{ .position = board.position })
                 else
                     board_helpers.capturewhitepiece(newpos, b.Board{ .position = board.position });
-                if (piece.color == 0) {
-                    newBoard.position.whitepieces.Bishop[index].position = newpos;
-                } else {
-                    newBoard.position.blackpieces.Bishop[index].position = newpos;
-                }
+                var moved = piece;
+                moved.position = newpos;
+                placeBishop(&newBoard, moved);
                 newBoard.position.sidetomove = next_side;
                 moves[possiblemoves] = newBoard;
                 possiblemoves += 1;

--- a/src/moves/knight.zig
+++ b/src/moves/knight.zig
@@ -3,36 +3,30 @@ const c = @import("../consts.zig");
 const board_helpers = @import("../utils/board_helpers.zig");
 const std = @import("std");
 
+fn placeKnight(board: *b.Board, piece: b.Piece) void {
+    var updated = piece;
+    const idx: usize = @intCast(piece.index);
+    if (piece.color == 0) {
+        if (piece.is_promoted) {
+            board.position.whitepieces.Promoted.Knight[idx] = updated;
+        } else {
+            board.position.whitepieces.Knight[idx] = updated;
+        }
+    } else {
+        if (piece.is_promoted) {
+            board.position.blackpieces.Promoted.Knight[idx] = updated;
+        } else {
+            board.position.blackpieces.Knight[idx] = updated;
+        }
+    }
+}
+
 pub fn getValidKnightMoves(piece: b.Piece, board: b.Board) []b.Board {
     const bitmap: u64 = board_helpers.bitmapfromboard(board);
     var moves: [256]b.Board = undefined;
     var possiblemoves: usize = 0;
 
     const next_side: u8 = if (board.position.sidetomove == 0) 1 else 0;
-
-    // Find the correct index for the knight
-    var index: u8 = 0;
-    if (piece.color == 0) {
-        // White knight
-        if (board.position.whitepieces.Knight[0].position == piece.position) {
-            index = 0;
-        } else if (board.position.whitepieces.Knight[1].position == piece.position) {
-            index = 1;
-        } else {
-            // Knight not found, return empty array
-            return moves[0..0];
-        }
-    } else {
-        // Black knight
-        if (board.position.blackpieces.Knight[0].position == piece.position) {
-            index = 0;
-        } else if (board.position.blackpieces.Knight[1].position == piece.position) {
-            index = 1;
-        } else {
-            // Knight not found, return empty array
-            return moves[0..0];
-        }
-    }
 
     // Define all possible knight move shifts
     // These represent the 8 possible L-shaped moves a knight can make
@@ -66,11 +60,9 @@ pub fn getValidKnightMoves(piece: b.Piece, board: b.Board) []b.Board {
         if (bitmap & newpos == 0) {
             // Empty square - add move
             var newBoard = b.Board{ .position = board.position };
-            if (piece.color == 0) {
-                newBoard.position.whitepieces.Knight[index].position = newpos;
-            } else {
-                newBoard.position.blackpieces.Knight[index].position = newpos;
-            }
+            var moved = piece;
+            moved.position = newpos;
+            placeKnight(&newBoard, moved);
             newBoard.position.sidetomove = next_side;
             moves[possiblemoves] = newBoard;
             possiblemoves += 1;
@@ -84,11 +76,9 @@ pub fn getValidKnightMoves(piece: b.Piece, board: b.Board) []b.Board {
                 else
                     board_helpers.capturewhitepiece(newpos, b.Board{ .position = board.position });
 
-                if (piece.color == 0) {
-                    newBoard.position.whitepieces.Knight[index].position = newpos;
-                } else {
-                    newBoard.position.blackpieces.Knight[index].position = newpos;
-                }
+                var moved = piece;
+                moved.position = newpos;
+                placeKnight(&newBoard, moved);
                 newBoard.position.sidetomove = next_side;
                 moves[possiblemoves] = newBoard;
                 possiblemoves += 1;

--- a/src/moves/pawn.zig
+++ b/src/moves/pawn.zig
@@ -8,9 +8,10 @@ pub fn getValidPawnMoves(piece: b.Piece, board: b.Board) []b.Board {
     const bitmap: u64 = board_helpers.bitmapfromboard(board);
     var moves: [256]b.Board = undefined;
     var possiblemoves: u6 = 0;
-    var index: u64 = 0;
+    var index: usize = 0;
 
     const next_side: u8 = if (board.position.sidetomove == 0) 1 else 0;
+    const promotions = [_]u8{ 'q', 'r', 'b', 'n' };
 
     // Find which pawn we're moving
     if (piece.color == 0) {
@@ -47,54 +48,55 @@ pub fn getValidPawnMoves(piece: b.Piece, board: b.Board) []b.Board {
     }
 
     if (bitmap & oneSquareForward == 0) {
-        if ((piece.color == 0 and currentRow < 7) or (piece.color == 1 and currentRow > 2)) {
-            // Regular move
-            var newBoard = b.Board{ .position = board.position };
-            if (piece.color == 0) {
-                newBoard.position.whitepieces.Pawn[index].position = oneSquareForward;
-            } else {
-                newBoard.position.blackpieces.Pawn[index].position = oneSquareForward;
-            }
-            newBoard.position.sidetomove = next_side;
-            moves[possiblemoves] = newBoard;
-            possiblemoves += 1;
-        } else if ((piece.color == 0 and currentRow == 7) or (piece.color == 1 and currentRow == 2)) {
-            // Promotion
-            var newBoard = b.Board{ .position = board.position };
-            if (piece.color == 0) {
-                newBoard.position.whitepieces.Pawn[index].position = oneSquareForward;
-                newBoard.position.whitepieces.Pawn[index].representation = 'Q';
-            } else {
-                newBoard.position.blackpieces.Pawn[index].position = oneSquareForward;
-                newBoard.position.blackpieces.Pawn[index].representation = 'q';
-            }
-            newBoard.position.sidetomove = next_side;
-            moves[possiblemoves] = newBoard;
-            possiblemoves += 1;
-        }
-
-        // Two square forward move from starting position
-        if (currentRow == startingRow) {
-            var twoSquareForward: u64 = 0;
-            if (forwardShift > 0) {
-                twoSquareForward = piece.position << @as(u6, @intCast(forwardShift * 2));
-            } else {
-                twoSquareForward = piece.position >> @as(u6, @intCast(-forwardShift * 2));
-            }
-
-            if (bitmap & twoSquareForward == 0) {
+        if ((piece.color == 0 and currentRow == 7) or (piece.color == 1 and currentRow == 2)) {
+            for (promotions) |promo| {
                 var newBoard = b.Board{ .position = board.position };
                 if (piece.color == 0) {
-                    newBoard.position.whitepieces.Pawn[index].position = twoSquareForward;
-                    // Set en passant square
-                    newBoard.position.enPassantSquare = oneSquareForward;
+                    newBoard.position.clearPawnSlot(0, index);
+                    newBoard.position.addPromotedPiece(0, promo, oneSquareForward);
                 } else {
-                    newBoard.position.blackpieces.Pawn[index].position = twoSquareForward;
-                    newBoard.position.enPassantSquare = oneSquareForward;
+                    newBoard.position.clearPawnSlot(1, index);
+                    newBoard.position.addPromotedPiece(1, promo, oneSquareForward);
                 }
+                newBoard.position.enPassantSquare = 0;
                 newBoard.position.sidetomove = next_side;
                 moves[possiblemoves] = newBoard;
                 possiblemoves += 1;
+            }
+        } else {
+            var newBoard = b.Board{ .position = board.position };
+            if (piece.color == 0) {
+                newBoard.position.whitepieces.Pawn[index].position = oneSquareForward;
+            } else {
+                newBoard.position.blackpieces.Pawn[index].position = oneSquareForward;
+            }
+            newBoard.position.enPassantSquare = 0;
+            newBoard.position.sidetomove = next_side;
+            moves[possiblemoves] = newBoard;
+            possiblemoves += 1;
+
+            // Two square forward move from starting position
+            if (currentRow == startingRow) {
+                var twoSquareForward: u64 = 0;
+                if (forwardShift > 0) {
+                    twoSquareForward = piece.position << @as(u6, @intCast(forwardShift * 2));
+                } else {
+                    twoSquareForward = piece.position >> @as(u6, @intCast(-forwardShift * 2));
+                }
+
+                if (bitmap & twoSquareForward == 0) {
+                    var doubleBoard = b.Board{ .position = board.position };
+                    if (piece.color == 0) {
+                        doubleBoard.position.whitepieces.Pawn[index].position = twoSquareForward;
+                        doubleBoard.position.enPassantSquare = oneSquareForward;
+                    } else {
+                        doubleBoard.position.blackpieces.Pawn[index].position = twoSquareForward;
+                        doubleBoard.position.enPassantSquare = oneSquareForward;
+                    }
+                    doubleBoard.position.sidetomove = next_side;
+                    moves[possiblemoves] = doubleBoard;
+                    possiblemoves += 1;
+                }
             }
         }
     }
@@ -123,13 +125,19 @@ pub fn getValidPawnMoves(piece: b.Piece, board: b.Board) []b.Board {
                     board_helpers.capturewhitepiece(leftCapture, b.Board{ .position = board.position });
 
                 if ((piece.color == 0 and currentRow == 7) or (piece.color == 1 and currentRow == 2)) {
-                    // Promotion on capture
-                    if (piece.color == 0) {
-                        newBoard.position.whitepieces.Pawn[index].position = leftCapture;
-                        newBoard.position.whitepieces.Pawn[index].representation = 'Q';
-                    } else {
-                        newBoard.position.blackpieces.Pawn[index].position = leftCapture;
-                        newBoard.position.blackpieces.Pawn[index].representation = 'q';
+                    for (promotions) |promo| {
+                        var promotedBoard = newBoard;
+                        if (piece.color == 0) {
+                            promotedBoard.position.clearPawnSlot(0, index);
+                            promotedBoard.position.addPromotedPiece(0, promo, leftCapture);
+                        } else {
+                            promotedBoard.position.clearPawnSlot(1, index);
+                            promotedBoard.position.addPromotedPiece(1, promo, leftCapture);
+                        }
+                        promotedBoard.position.enPassantSquare = 0;
+                        promotedBoard.position.sidetomove = next_side;
+                        moves[possiblemoves] = promotedBoard;
+                        possiblemoves += 1;
                     }
                 } else {
                     if (piece.color == 0) {
@@ -137,10 +145,11 @@ pub fn getValidPawnMoves(piece: b.Piece, board: b.Board) []b.Board {
                     } else {
                         newBoard.position.blackpieces.Pawn[index].position = leftCapture;
                     }
+                    newBoard.position.enPassantSquare = 0;
+                    newBoard.position.sidetomove = next_side;
+                    moves[possiblemoves] = newBoard;
+                    possiblemoves += 1;
                 }
-                newBoard.position.sidetomove = next_side;
-                moves[possiblemoves] = newBoard;
-                possiblemoves += 1;
             }
         } else if (leftCapture == board.position.enPassantSquare) {
             // En passant capture to the left
@@ -176,13 +185,19 @@ pub fn getValidPawnMoves(piece: b.Piece, board: b.Board) []b.Board {
                     board_helpers.capturewhitepiece(rightCapture, b.Board{ .position = board.position });
 
                 if ((piece.color == 0 and currentRow == 7) or (piece.color == 1 and currentRow == 2)) {
-                    // Promotion on capture
-                    if (piece.color == 0) {
-                        newBoard.position.whitepieces.Pawn[index].position = rightCapture;
-                        newBoard.position.whitepieces.Pawn[index].representation = 'Q';
-                    } else {
-                        newBoard.position.blackpieces.Pawn[index].position = rightCapture;
-                        newBoard.position.blackpieces.Pawn[index].representation = 'q';
+                    for (promotions) |promo| {
+                        var promotedBoard = newBoard;
+                        if (piece.color == 0) {
+                            promotedBoard.position.clearPawnSlot(0, index);
+                            promotedBoard.position.addPromotedPiece(0, promo, rightCapture);
+                        } else {
+                            promotedBoard.position.clearPawnSlot(1, index);
+                            promotedBoard.position.addPromotedPiece(1, promo, rightCapture);
+                        }
+                        promotedBoard.position.enPassantSquare = 0;
+                        promotedBoard.position.sidetomove = next_side;
+                        moves[possiblemoves] = promotedBoard;
+                        possiblemoves += 1;
                     }
                 } else {
                     if (piece.color == 0) {
@@ -190,10 +205,11 @@ pub fn getValidPawnMoves(piece: b.Piece, board: b.Board) []b.Board {
                     } else {
                         newBoard.position.blackpieces.Pawn[index].position = rightCapture;
                     }
+                    newBoard.position.enPassantSquare = 0;
+                    newBoard.position.sidetomove = next_side;
+                    moves[possiblemoves] = newBoard;
+                    possiblemoves += 1;
                 }
-                newBoard.position.sidetomove = next_side;
-                moves[possiblemoves] = newBoard;
-                possiblemoves += 1;
             }
         } else if (rightCapture == board.position.enPassantSquare) {
             // En passant capture to the right
@@ -231,7 +247,7 @@ test "getValidPawnMoves from e7 in empty board" {
     var board = b.Board{ .position = b.Position.emptyboard() };
     board.position.whitepieces.Pawn[3].position = c.E7;
     const moves = getValidPawnMoves(board.position.whitepieces.Pawn[3], board);
-    try std.testing.expectEqual(moves.len, 1);
+    try std.testing.expectEqual(moves.len, 4);
 }
 
 test "getValidPawnMoves for black pawn from e7 in start position" {
@@ -244,8 +260,24 @@ test "getValidPawnMoves for black pawn from e2 in empty board" {
     var board = b.Board{ .position = b.Position.emptyboard() };
     board.position.blackpieces.Pawn[3].position = c.E2;
     const moves = getValidPawnMoves(board.position.blackpieces.Pawn[3], board);
-    try std.testing.expectEqual(moves.len, 1); // One move to e1 with promotion
-    try std.testing.expectEqual(moves[0].position.blackpieces.Pawn[3].representation, 'q');
+    try std.testing.expectEqual(moves.len, 4);
+
+    var seen = [_]bool{ false, false, false, false };
+    for (moves, 0..) |move, idx| {
+        _ = idx;
+        try std.testing.expectEqual(move.position.blackpieces.Pawn[3].position, 0);
+        const promoted = board_helpers.piecefromlocation(c.E1, move);
+        try std.testing.expect(promoted.is_promoted);
+        try std.testing.expectEqual(promoted.color, 1);
+        switch (promoted.representation) {
+            'q' => seen[0] = true,
+            'r' => seen[1] = true,
+            'b' => seen[2] = true,
+            'n' => seen[3] = true,
+            else => try std.testing.expect(false),
+        }
+    }
+    for (seen) |flag| try std.testing.expect(flag);
 }
 
 test "getValidPawnMoves for black pawn capture" {
@@ -288,24 +320,64 @@ test "getValidPawnMoves for black pawn promotion on capture" {
     board.position.blackpieces.Pawn[3].position = c.E2;
     board.position.whitepieces.Pawn[2].position = c.D1;
     const moves = getValidPawnMoves(board.position.blackpieces.Pawn[3], board);
+    try std.testing.expectEqual(moves.len, 8);
 
-    var foundPromotionCapture = false;
+    var forward_seen = [_]bool{ false, false, false, false };
+    var capture_seen = [_]bool{ false, false, false, false };
     for (moves) |move| {
-        if (move.position.blackpieces.Pawn[3].position == c.D1) {
-            foundPromotionCapture = true;
-            try std.testing.expectEqual(move.position.whitepieces.Pawn[2].position, 0);
-            try std.testing.expectEqual(move.position.blackpieces.Pawn[3].representation, 'q');
+        const forward = board_helpers.piecefromlocation(c.E1, move);
+        if (forward.color == 1 and forward.is_promoted) {
+            try std.testing.expectEqual(move.position.blackpieces.Pawn[3].position, 0);
+            switch (forward.representation) {
+                'q' => forward_seen[0] = true,
+                'r' => forward_seen[1] = true,
+                'b' => forward_seen[2] = true,
+                'n' => forward_seen[3] = true,
+                else => try std.testing.expect(false),
+            }
+            continue;
         }
+
+        const promoted = board_helpers.piecefromlocation(c.D1, move);
+        if (promoted.color == 1 and promoted.is_promoted) {
+            try std.testing.expectEqual(move.position.whitepieces.Pawn[2].position, 0);
+            switch (promoted.representation) {
+                'q' => capture_seen[0] = true,
+                'r' => capture_seen[1] = true,
+                'b' => capture_seen[2] = true,
+                'n' => capture_seen[3] = true,
+                else => try std.testing.expect(false),
+            }
+            continue;
+        }
+
+        try std.testing.expect(false);
     }
-    try std.testing.expect(foundPromotionCapture);
+    for (forward_seen) |flag| try std.testing.expect(flag);
+    for (capture_seen) |flag| try std.testing.expect(flag);
 }
 
 test "getValidPawnMoves promotion on reaching 8th rank" {
     var board = b.Board{ .position = b.Position.emptyboard() };
     board.position.whitepieces.Pawn[0].position = c.E7;
     const moves = getValidPawnMoves(board.position.whitepieces.Pawn[0], board);
-    try std.testing.expectEqual(moves.len, 1);
-    try std.testing.expectEqual(moves[0].position.whitepieces.Pawn[0].representation, 'Q');
+    try std.testing.expectEqual(moves.len, 4);
+
+    var seen = [_]bool{ false, false, false, false };
+    for (moves) |move| {
+        const promoted = board_helpers.piecefromlocation(c.E8, move);
+        try std.testing.expect(promoted.is_promoted);
+        try std.testing.expectEqual(promoted.color, 0);
+        try std.testing.expectEqual(move.position.whitepieces.Pawn[0].position, 0);
+        switch (promoted.representation) {
+            'Q' => seen[0] = true,
+            'R' => seen[1] = true,
+            'B' => seen[2] = true,
+            'N' => seen[3] = true,
+            else => try std.testing.expect(false),
+        }
+    }
+    for (seen) |flag| try std.testing.expect(flag);
 }
 
 test "getValidPawnMoves promotion on capture" {
@@ -313,15 +385,41 @@ test "getValidPawnMoves promotion on capture" {
     board.position.whitepieces.Pawn[0].position = c.E7;
     board.position.blackpieces.Pawn[0].position = c.F8;
     const moves = getValidPawnMoves(board.position.whitepieces.Pawn[0], board);
-    try std.testing.expectEqual(moves.len, 2); // One forward promotion, one capture promotion
-    var foundCapture = false;
+    try std.testing.expectEqual(moves.len, 8); // Four forward promotions and four capture promotions
+
+    var forward_seen = [_]bool{ false, false, false, false };
+    var capture_seen = [_]bool{ false, false, false, false };
     for (moves) |move| {
-        if (move.position.blackpieces.Pawn[0].position == 0) {
-            foundCapture = true;
-            try std.testing.expectEqual(move.position.whitepieces.Pawn[0].representation, 'Q');
+        const forward = board_helpers.piecefromlocation(c.E8, move);
+        if (forward.color == 0 and forward.is_promoted) {
+            try std.testing.expectEqual(move.position.whitepieces.Pawn[0].position, 0);
+            switch (forward.representation) {
+                'Q' => forward_seen[0] = true,
+                'R' => forward_seen[1] = true,
+                'B' => forward_seen[2] = true,
+                'N' => forward_seen[3] = true,
+                else => try std.testing.expect(false),
+            }
+            continue;
         }
+
+        const capture = board_helpers.piecefromlocation(c.F8, move);
+        if (capture.color == 0 and capture.is_promoted) {
+            try std.testing.expectEqual(move.position.blackpieces.Pawn[0].position, 0);
+            switch (capture.representation) {
+                'Q' => capture_seen[0] = true,
+                'R' => capture_seen[1] = true,
+                'B' => capture_seen[2] = true,
+                'N' => capture_seen[3] = true,
+                else => try std.testing.expect(false),
+            }
+            continue;
+        }
+
+        try std.testing.expect(false); // Unexpected board state
     }
-    try std.testing.expect(foundCapture);
+    for (forward_seen) |flag| try std.testing.expect(flag);
+    for (capture_seen) |flag| try std.testing.expect(flag);
 }
 
 test "getValidPawnMoves en passant capture" {

--- a/src/moves/queen.zig
+++ b/src/moves/queen.zig
@@ -3,6 +3,24 @@ const c = @import("../consts.zig");
 const board_helpers = @import("../utils/board_helpers.zig");
 const std = @import("std");
 
+fn placeQueen(board: *b.Board, piece: b.Piece) void {
+    var updated = piece;
+    const idx: usize = @intCast(piece.index);
+    if (piece.color == 0) {
+        if (piece.is_promoted) {
+            board.position.whitepieces.Promoted.Queen[idx] = updated;
+        } else {
+            board.position.whitepieces.Queen = updated;
+        }
+    } else {
+        if (piece.is_promoted) {
+            board.position.blackpieces.Promoted.Queen[idx] = updated;
+        } else {
+            board.position.blackpieces.Queen = updated;
+        }
+    }
+}
+
 pub fn getValidQueenMoves(piece: b.Piece, board: b.Board) []b.Board {
     const bitmap: u64 = board_helpers.bitmapfromboard(board);
     var moves: [256]b.Board = undefined;
@@ -28,11 +46,7 @@ pub fn getValidQueenMoves(piece: b.Piece, board: b.Board) []b.Board {
             newqueen.position = newpos;
             moves[possiblemoves] = b.Board{ .position = board.position };
             moves[possiblemoves].position.sidetomove = next_side;
-            if (queen_piece.color == 0) {
-                moves[possiblemoves].position.whitepieces.Queen = newqueen;
-            } else {
-                moves[possiblemoves].position.blackpieces.Queen = newqueen;
-            }
+            placeQueen(&moves[possiblemoves], newqueen);
             possiblemoves += 1;
         } else {
             // Check for capture
@@ -41,13 +55,11 @@ pub fn getValidQueenMoves(piece: b.Piece, board: b.Board) []b.Board {
                 newqueen.position = newpos;
                 if (queen_piece.color == 0) {
                     moves[possiblemoves] = board_helpers.captureblackpiece(newpos, b.Board{ .position = board.position });
-                    moves[possiblemoves].position.sidetomove = next_side;
-                    moves[possiblemoves].position.whitepieces.Queen = newqueen;
                 } else {
                     moves[possiblemoves] = board_helpers.capturewhitepiece(newpos, b.Board{ .position = board.position });
-                    moves[possiblemoves].position.sidetomove = next_side;
-                    moves[possiblemoves].position.blackpieces.Queen = newqueen;
                 }
+                moves[possiblemoves].position.sidetomove = next_side;
+                placeQueen(&moves[possiblemoves], newqueen);
                 possiblemoves += 1;
             }
             break;
@@ -65,11 +77,7 @@ pub fn getValidQueenMoves(piece: b.Piece, board: b.Board) []b.Board {
             newqueen.position = newpos;
             moves[possiblemoves] = b.Board{ .position = board.position };
             moves[possiblemoves].position.sidetomove = next_side;
-            if (queen_piece.color == 0) {
-                moves[possiblemoves].position.whitepieces.Queen = newqueen;
-            } else {
-                moves[possiblemoves].position.blackpieces.Queen = newqueen;
-            }
+            placeQueen(&moves[possiblemoves], newqueen);
             possiblemoves += 1;
         } else {
             // Check for capture
@@ -78,13 +86,11 @@ pub fn getValidQueenMoves(piece: b.Piece, board: b.Board) []b.Board {
                 newqueen.position = newpos;
                 if (queen_piece.color == 0) {
                     moves[possiblemoves] = board_helpers.captureblackpiece(newpos, b.Board{ .position = board.position });
-                    moves[possiblemoves].position.sidetomove = next_side;
-                    moves[possiblemoves].position.whitepieces.Queen = newqueen;
                 } else {
                     moves[possiblemoves] = board_helpers.capturewhitepiece(newpos, b.Board{ .position = board.position });
-                    moves[possiblemoves].position.sidetomove = next_side;
-                    moves[possiblemoves].position.blackpieces.Queen = newqueen;
                 }
+                moves[possiblemoves].position.sidetomove = next_side;
+                placeQueen(&moves[possiblemoves], newqueen);
                 possiblemoves += 1;
             }
             break;
@@ -102,11 +108,7 @@ pub fn getValidQueenMoves(piece: b.Piece, board: b.Board) []b.Board {
             newqueen.position = newpos;
             moves[possiblemoves] = b.Board{ .position = board.position };
             moves[possiblemoves].position.sidetomove = next_side;
-            if (queen_piece.color == 0) {
-                moves[possiblemoves].position.whitepieces.Queen = newqueen;
-            } else {
-                moves[possiblemoves].position.blackpieces.Queen = newqueen;
-            }
+            placeQueen(&moves[possiblemoves], newqueen);
             possiblemoves += 1;
         } else {
             // Check for capture
@@ -115,13 +117,11 @@ pub fn getValidQueenMoves(piece: b.Piece, board: b.Board) []b.Board {
                 newqueen.position = newpos;
                 if (queen_piece.color == 0) {
                     moves[possiblemoves] = board_helpers.captureblackpiece(newpos, b.Board{ .position = board.position });
-                    moves[possiblemoves].position.sidetomove = next_side;
-                    moves[possiblemoves].position.whitepieces.Queen = newqueen;
                 } else {
                     moves[possiblemoves] = board_helpers.capturewhitepiece(newpos, b.Board{ .position = board.position });
-                    moves[possiblemoves].position.sidetomove = next_side;
-                    moves[possiblemoves].position.blackpieces.Queen = newqueen;
                 }
+                moves[possiblemoves].position.sidetomove = next_side;
+                placeQueen(&moves[possiblemoves], newqueen);
                 possiblemoves += 1;
             }
             break;
@@ -139,11 +139,7 @@ pub fn getValidQueenMoves(piece: b.Piece, board: b.Board) []b.Board {
             newqueen.position = newpos;
             moves[possiblemoves] = b.Board{ .position = board.position };
             moves[possiblemoves].position.sidetomove = next_side;
-            if (queen_piece.color == 0) {
-                moves[possiblemoves].position.whitepieces.Queen = newqueen;
-            } else {
-                moves[possiblemoves].position.blackpieces.Queen = newqueen;
-            }
+            placeQueen(&moves[possiblemoves], newqueen);
             possiblemoves += 1;
         } else {
             // Check for capture
@@ -152,13 +148,11 @@ pub fn getValidQueenMoves(piece: b.Piece, board: b.Board) []b.Board {
                 newqueen.position = newpos;
                 if (queen_piece.color == 0) {
                     moves[possiblemoves] = board_helpers.captureblackpiece(newpos, b.Board{ .position = board.position });
-                    moves[possiblemoves].position.sidetomove = next_side;
-                    moves[possiblemoves].position.whitepieces.Queen = newqueen;
                 } else {
                     moves[possiblemoves] = board_helpers.capturewhitepiece(newpos, b.Board{ .position = board.position });
-                    moves[possiblemoves].position.sidetomove = next_side;
-                    moves[possiblemoves].position.blackpieces.Queen = newqueen;
                 }
+                moves[possiblemoves].position.sidetomove = next_side;
+                placeQueen(&moves[possiblemoves], newqueen);
                 possiblemoves += 1;
             }
             break;
@@ -177,11 +171,7 @@ pub fn getValidQueenMoves(piece: b.Piece, board: b.Board) []b.Board {
             newqueen.position = newpos;
             moves[possiblemoves] = b.Board{ .position = board.position };
             moves[possiblemoves].position.sidetomove = next_side;
-            if (queen_piece.color == 0) {
-                moves[possiblemoves].position.whitepieces.Queen = newqueen;
-            } else {
-                moves[possiblemoves].position.blackpieces.Queen = newqueen;
-            }
+            placeQueen(&moves[possiblemoves], newqueen);
             possiblemoves += 1;
         } else {
             // Check for capture
@@ -190,13 +180,11 @@ pub fn getValidQueenMoves(piece: b.Piece, board: b.Board) []b.Board {
                 newqueen.position = newpos;
                 if (queen_piece.color == 0) {
                     moves[possiblemoves] = board_helpers.captureblackpiece(newpos, b.Board{ .position = board.position });
-                    moves[possiblemoves].position.sidetomove = next_side;
-                    moves[possiblemoves].position.whitepieces.Queen = newqueen;
                 } else {
                     moves[possiblemoves] = board_helpers.capturewhitepiece(newpos, b.Board{ .position = board.position });
-                    moves[possiblemoves].position.sidetomove = next_side;
-                    moves[possiblemoves].position.blackpieces.Queen = newqueen;
                 }
+                moves[possiblemoves].position.sidetomove = next_side;
+                placeQueen(&moves[possiblemoves], newqueen);
                 possiblemoves += 1;
             }
             break;
@@ -214,11 +202,7 @@ pub fn getValidQueenMoves(piece: b.Piece, board: b.Board) []b.Board {
             newqueen.position = newpos;
             moves[possiblemoves] = b.Board{ .position = board.position };
             moves[possiblemoves].position.sidetomove = next_side;
-            if (queen_piece.color == 0) {
-                moves[possiblemoves].position.whitepieces.Queen = newqueen;
-            } else {
-                moves[possiblemoves].position.blackpieces.Queen = newqueen;
-            }
+            placeQueen(&moves[possiblemoves], newqueen);
             possiblemoves += 1;
         } else {
             // Check for capture
@@ -227,13 +211,11 @@ pub fn getValidQueenMoves(piece: b.Piece, board: b.Board) []b.Board {
                 newqueen.position = newpos;
                 if (queen_piece.color == 0) {
                     moves[possiblemoves] = board_helpers.captureblackpiece(newpos, b.Board{ .position = board.position });
-                    moves[possiblemoves].position.sidetomove = next_side;
-                    moves[possiblemoves].position.whitepieces.Queen = newqueen;
                 } else {
                     moves[possiblemoves] = board_helpers.capturewhitepiece(newpos, b.Board{ .position = board.position });
-                    moves[possiblemoves].position.sidetomove = next_side;
-                    moves[possiblemoves].position.blackpieces.Queen = newqueen;
                 }
+                moves[possiblemoves].position.sidetomove = next_side;
+                placeQueen(&moves[possiblemoves], newqueen);
                 possiblemoves += 1;
             }
             break;
@@ -251,11 +233,7 @@ pub fn getValidQueenMoves(piece: b.Piece, board: b.Board) []b.Board {
             newqueen.position = newpos;
             moves[possiblemoves] = b.Board{ .position = board.position };
             moves[possiblemoves].position.sidetomove = next_side;
-            if (queen_piece.color == 0) {
-                moves[possiblemoves].position.whitepieces.Queen = newqueen;
-            } else {
-                moves[possiblemoves].position.blackpieces.Queen = newqueen;
-            }
+            placeQueen(&moves[possiblemoves], newqueen);
             possiblemoves += 1;
         } else {
             // Check for capture
@@ -264,13 +242,11 @@ pub fn getValidQueenMoves(piece: b.Piece, board: b.Board) []b.Board {
                 newqueen.position = newpos;
                 if (queen_piece.color == 0) {
                     moves[possiblemoves] = board_helpers.captureblackpiece(newpos, b.Board{ .position = board.position });
-                    moves[possiblemoves].position.sidetomove = next_side;
-                    moves[possiblemoves].position.whitepieces.Queen = newqueen;
                 } else {
                     moves[possiblemoves] = board_helpers.capturewhitepiece(newpos, b.Board{ .position = board.position });
-                    moves[possiblemoves].position.sidetomove = next_side;
-                    moves[possiblemoves].position.blackpieces.Queen = newqueen;
                 }
+                moves[possiblemoves].position.sidetomove = next_side;
+                placeQueen(&moves[possiblemoves], newqueen);
                 possiblemoves += 1;
             }
             break;
@@ -287,11 +263,7 @@ pub fn getValidQueenMoves(piece: b.Piece, board: b.Board) []b.Board {
             // Empty square
             newqueen.position = newpos;
             moves[possiblemoves] = b.Board{ .position = board.position };
-            if (queen_piece.color == 0) {
-                moves[possiblemoves].position.whitepieces.Queen = newqueen;
-            } else {
-                moves[possiblemoves].position.blackpieces.Queen = newqueen;
-            }
+            placeQueen(&moves[possiblemoves], newqueen);
             possiblemoves += 1;
         } else {
             // Check for capture
@@ -300,11 +272,10 @@ pub fn getValidQueenMoves(piece: b.Piece, board: b.Board) []b.Board {
                 newqueen.position = newpos;
                 if (queen_piece.color == 0) {
                     moves[possiblemoves] = board_helpers.captureblackpiece(newpos, b.Board{ .position = board.position });
-                    moves[possiblemoves].position.whitepieces.Queen = newqueen;
                 } else {
                     moves[possiblemoves] = board_helpers.capturewhitepiece(newpos, b.Board{ .position = board.position });
-                    moves[possiblemoves].position.blackpieces.Queen = newqueen;
                 }
+                placeQueen(&moves[possiblemoves], newqueen);
                 possiblemoves += 1;
             }
             break;

--- a/src/moves/rook.zig
+++ b/src/moves/rook.zig
@@ -3,31 +3,31 @@ const c = @import("../consts.zig");
 const board_helpers = @import("../utils/board_helpers.zig");
 const std = @import("std");
 
+fn placeRook(board: *b.Board, piece: b.Piece) void {
+    var updated = piece;
+    const idx: usize = @intCast(piece.index);
+    if (piece.color == 0) {
+        if (piece.is_promoted) {
+            board.position.whitepieces.Promoted.Rook[idx] = updated;
+        } else {
+            board.position.whitepieces.Rook[idx] = updated;
+        }
+    } else {
+        if (piece.is_promoted) {
+            board.position.blackpieces.Promoted.Rook[idx] = updated;
+        } else {
+            board.position.blackpieces.Rook[idx] = updated;
+        }
+    }
+}
+
 pub fn getValidRookMoves(piece: b.Piece, board: b.Board) []b.Board {
     const bitmap: u64 = board_helpers.bitmapfromboard(board);
     var moves: [256]b.Board = undefined;
     var possiblemoves: usize = 0;
-    var index: usize = 0; // Initialize with a default value
 
     const next_side: u8 = if (board.position.sidetomove == 0) 1 else 0;
     const from_square = piece.position;
-
-    // Find which rook we're moving
-    if (piece.color == 0) {
-        for (board.position.whitepieces.Rook, 0..) |item, loopidx| {
-            if (item.position == piece.position) {
-                index = loopidx;
-                break;
-            }
-        }
-    } else {
-        for (board.position.blackpieces.Rook, 0..) |item, loopidx| {
-            if (item.position == piece.position) {
-                index = loopidx;
-                break;
-            }
-        }
-    }
 
     const row: u64 = board_helpers.rowfrombitmap(piece.position);
     const col: u64 = board_helpers.colfrombitmap(piece.position);
@@ -60,21 +60,24 @@ pub fn getValidRookMoves(piece: b.Piece, board: b.Board) []b.Board {
             // Check if square is empty
             if (bitmap & newpos == 0) {
                 var newBoard = b.Board{ .position = board.position };
-                if (piece.color == 0) {
-                    newBoard.position.whitepieces.Rook[index].position = newpos;
-                    if (from_square == c.A1) {
-                        newBoard.position.canCastleWhiteQueenside = false;
-                    } else if (from_square == c.H1) {
-                        newBoard.position.canCastleWhiteKingside = false;
-                    }
-                } else {
-                    newBoard.position.blackpieces.Rook[index].position = newpos;
-                    if (from_square == c.A8) {
-                        newBoard.position.canCastleBlackQueenside = false;
-                    } else if (from_square == c.H8) {
-                        newBoard.position.canCastleBlackKingside = false;
+                var moved = piece;
+                moved.position = newpos;
+                if (!piece.is_promoted) {
+                    if (piece.color == 0) {
+                        if (from_square == c.A1) {
+                            newBoard.position.canCastleWhiteQueenside = false;
+                        } else if (from_square == c.H1) {
+                            newBoard.position.canCastleWhiteKingside = false;
+                        }
+                    } else {
+                        if (from_square == c.A8) {
+                            newBoard.position.canCastleBlackQueenside = false;
+                        } else if (from_square == c.H8) {
+                            newBoard.position.canCastleBlackKingside = false;
+                        }
                     }
                 }
+                placeRook(&newBoard, moved);
                 newBoard.position.sidetomove = next_side;
                 moves[possiblemoves] = newBoard;
                 possiblemoves += 1;
@@ -87,21 +90,24 @@ pub fn getValidRookMoves(piece: b.Piece, board: b.Board) []b.Board {
                     else
                         board_helpers.capturewhitepiece(newpos, b.Board{ .position = board.position });
 
-                    if (piece.color == 0) {
-                        newBoard.position.whitepieces.Rook[index].position = newpos;
-                        if (from_square == c.A1) {
-                            newBoard.position.canCastleWhiteQueenside = false;
-                        } else if (from_square == c.H1) {
-                            newBoard.position.canCastleWhiteKingside = false;
-                        }
-                    } else {
-                        newBoard.position.blackpieces.Rook[index].position = newpos;
-                        if (from_square == c.A8) {
-                            newBoard.position.canCastleBlackQueenside = false;
-                        } else if (from_square == c.H8) {
-                            newBoard.position.canCastleBlackKingside = false;
+                    var moved = piece;
+                    moved.position = newpos;
+                    if (!piece.is_promoted) {
+                        if (piece.color == 0) {
+                            if (from_square == c.A1) {
+                                newBoard.position.canCastleWhiteQueenside = false;
+                            } else if (from_square == c.H1) {
+                                newBoard.position.canCastleWhiteKingside = false;
+                            }
+                        } else {
+                            if (from_square == c.A8) {
+                                newBoard.position.canCastleBlackQueenside = false;
+                            } else if (from_square == c.H8) {
+                                newBoard.position.canCastleBlackKingside = false;
+                            }
                         }
                     }
+                    placeRook(&newBoard, moved);
                     newBoard.position.sidetomove = next_side;
                     moves[possiblemoves] = newBoard;
                     possiblemoves += 1;

--- a/src/state.zig
+++ b/src/state.zig
@@ -54,6 +54,23 @@ pub fn isCheck(board: b.Board, isWhite: bool) bool {
                 }
             }
         }
+        for (board.position.blackpieces.Promoted.Knight) |knight| {
+            if (knight.position == 0 or !knight.is_promoted) continue;
+            for (knightShifts) |move| {
+                if (kingPosition & move.mask == 0) continue;
+
+                const candidate = if (move.shift > 0)
+                    kingPosition << @as(u6, @intCast(move.shift))
+                else
+                    kingPosition >> @as(u6, @intCast(-move.shift));
+
+                if (candidate == 0) continue;
+
+                if (candidate == knight.position) {
+                    return true;
+                }
+            }
+        }
 
         // Check black bishops
         for (board.position.blackpieces.Bishop) |bishop| {
@@ -65,6 +82,11 @@ pub fn isCheck(board: b.Board, isWhite: bool) bool {
                     move.position.blackpieces.Bishop[1].position == kingPosition)
                 {
                     return true;
+                }
+                for (move.position.blackpieces.Promoted.Bishop) |promoted| {
+                    if (promoted.position == kingPosition and promoted.is_promoted) {
+                        return true;
+                    }
                 }
             }
         }
@@ -80,6 +102,11 @@ pub fn isCheck(board: b.Board, isWhite: bool) bool {
                 {
                     return true;
                 }
+                for (move.position.blackpieces.Promoted.Rook) |promoted| {
+                    if (promoted.position == kingPosition and promoted.is_promoted) {
+                        return true;
+                    }
+                }
             }
         }
 
@@ -90,6 +117,25 @@ pub fn isCheck(board: b.Board, isWhite: bool) bool {
                 // Check if any of the queen's valid moves can reach the king's position
                 if (move.position.blackpieces.Queen.position == kingPosition) {
                     return true;
+                }
+                for (move.position.blackpieces.Promoted.Queen) |promoted| {
+                    if (promoted.position == kingPosition and promoted.is_promoted) {
+                        return true;
+                    }
+                }
+            }
+        }
+        for (board.position.blackpieces.Promoted.Queen) |queen| {
+            if (queen.position == 0 or !queen.is_promoted) continue;
+            const moves = m.ValidQueenMoves(queen, board);
+            for (moves) |move| {
+                if (move.position.blackpieces.Queen.position == kingPosition) {
+                    return true;
+                }
+                for (move.position.blackpieces.Promoted.Queen) |promoted| {
+                    if (promoted.position == kingPosition and promoted.is_promoted) {
+                        return true;
+                    }
                 }
             }
         }
@@ -126,6 +172,23 @@ pub fn isCheck(board: b.Board, isWhite: bool) bool {
                 }
             }
         }
+        for (board.position.whitepieces.Promoted.Knight) |knight| {
+            if (knight.position == 0 or !knight.is_promoted) continue;
+            for (knightShifts) |move| {
+                if (kingPosition & move.mask == 0) continue;
+
+                const candidate = if (move.shift > 0)
+                    kingPosition << @as(u6, @intCast(move.shift))
+                else
+                    kingPosition >> @as(u6, @intCast(-move.shift));
+
+                if (candidate == 0) continue;
+
+                if (candidate == knight.position) {
+                    return true;
+                }
+            }
+        }
 
         // Check white bishops
         for (board.position.whitepieces.Bishop) |bishop| {
@@ -137,6 +200,11 @@ pub fn isCheck(board: b.Board, isWhite: bool) bool {
                     move.position.whitepieces.Bishop[1].position == kingPosition)
                 {
                     return true;
+                }
+                for (move.position.whitepieces.Promoted.Bishop) |promoted| {
+                    if (promoted.position == kingPosition and promoted.is_promoted) {
+                        return true;
+                    }
                 }
             }
         }
@@ -152,6 +220,11 @@ pub fn isCheck(board: b.Board, isWhite: bool) bool {
                 {
                     return true;
                 }
+                for (move.position.whitepieces.Promoted.Rook) |promoted| {
+                    if (promoted.position == kingPosition and promoted.is_promoted) {
+                        return true;
+                    }
+                }
             }
         }
 
@@ -162,6 +235,25 @@ pub fn isCheck(board: b.Board, isWhite: bool) bool {
                 // Check if any of the queen's valid moves can reach the king's position
                 if (move.position.whitepieces.Queen.position == kingPosition) {
                     return true;
+                }
+                for (move.position.whitepieces.Promoted.Queen) |promoted| {
+                    if (promoted.position == kingPosition and promoted.is_promoted) {
+                        return true;
+                    }
+                }
+            }
+        }
+        for (board.position.whitepieces.Promoted.Queen) |queen| {
+            if (queen.position == 0 or !queen.is_promoted) continue;
+            const moves = m.ValidQueenMoves(queen, board);
+            for (moves) |move| {
+                if (move.position.whitepieces.Queen.position == kingPosition) {
+                    return true;
+                }
+                for (move.position.whitepieces.Promoted.Queen) |promoted| {
+                    if (promoted.position == kingPosition and promoted.is_promoted) {
+                        return true;
+                    }
                 }
             }
         }
@@ -333,10 +425,24 @@ pub fn isCheckmate(board: b.Board, isWhite: bool) bool {
                 if (!isCheck(move, true)) return false;
             }
         }
+        for (board.position.whitepieces.Promoted.Knight) |knight| {
+            if (knight.position == 0 or !knight.is_promoted) continue;
+            const knightMoves = m.getValidKnightMoves(knight, board);
+            for (knightMoves) |move| {
+                if (!isCheck(move, true)) return false;
+            }
+        }
 
         // Check bishop moves
         for (board.position.whitepieces.Bishop) |bishop| {
             if (bishop.position == 0) continue;
+            const bishopMoves = m.getValidBishopMoves(bishop, board);
+            for (bishopMoves) |move| {
+                if (!isCheck(move, true)) return false;
+            }
+        }
+        for (board.position.whitepieces.Promoted.Bishop) |bishop| {
+            if (bishop.position == 0 or !bishop.is_promoted) continue;
             const bishopMoves = m.getValidBishopMoves(bishop, board);
             for (bishopMoves) |move| {
                 if (!isCheck(move, true)) return false;
@@ -351,10 +457,24 @@ pub fn isCheckmate(board: b.Board, isWhite: bool) bool {
                 if (!isCheck(move, true)) return false;
             }
         }
+        for (board.position.whitepieces.Promoted.Rook) |rook| {
+            if (rook.position == 0 or !rook.is_promoted) continue;
+            const rookMoves = m.getValidRookMoves(rook, board);
+            for (rookMoves) |move| {
+                if (!isCheck(move, true)) return false;
+            }
+        }
 
         // Check queen moves
         if (board.position.whitepieces.Queen.position != 0) {
             const queenMoves = m.ValidQueenMoves(board.position.whitepieces.Queen, board);
+            for (queenMoves) |move| {
+                if (!isCheck(move, true)) return false;
+            }
+        }
+        for (board.position.whitepieces.Promoted.Queen) |queen| {
+            if (queen.position == 0 or !queen.is_promoted) continue;
+            const queenMoves = m.ValidQueenMoves(queen, board);
             for (queenMoves) |move| {
                 if (!isCheck(move, true)) return false;
             }
@@ -384,10 +504,24 @@ pub fn isCheckmate(board: b.Board, isWhite: bool) bool {
                 if (!isCheck(move, false)) return false;
             }
         }
+        for (board.position.blackpieces.Promoted.Knight) |knight| {
+            if (knight.position == 0 or !knight.is_promoted) continue;
+            const knightMoves = m.getValidKnightMoves(knight, board);
+            for (knightMoves) |move| {
+                if (!isCheck(move, false)) return false;
+            }
+        }
 
         // Check bishop moves
         for (board.position.blackpieces.Bishop) |bishop| {
             if (bishop.position == 0) continue;
+            const bishopMoves = m.getValidBishopMoves(bishop, board);
+            for (bishopMoves) |move| {
+                if (!isCheck(move, false)) return false;
+            }
+        }
+        for (board.position.blackpieces.Promoted.Bishop) |bishop| {
+            if (bishop.position == 0 or !bishop.is_promoted) continue;
             const bishopMoves = m.getValidBishopMoves(bishop, board);
             for (bishopMoves) |move| {
                 if (!isCheck(move, false)) return false;
@@ -402,10 +536,24 @@ pub fn isCheckmate(board: b.Board, isWhite: bool) bool {
                 if (!isCheck(move, false)) return false;
             }
         }
+        for (board.position.blackpieces.Promoted.Rook) |rook| {
+            if (rook.position == 0 or !rook.is_promoted) continue;
+            const rookMoves = m.getValidRookMoves(rook, board);
+            for (rookMoves) |move| {
+                if (!isCheck(move, false)) return false;
+            }
+        }
 
         // Check queen moves
         if (board.position.blackpieces.Queen.position != 0) {
             const queenMoves = m.ValidQueenMoves(board.position.blackpieces.Queen, board);
+            for (queenMoves) |move| {
+                if (!isCheck(move, false)) return false;
+            }
+        }
+        for (board.position.blackpieces.Promoted.Queen) |queen| {
+            if (queen.position == 0 or !queen.is_promoted) continue;
+            const queenMoves = m.ValidQueenMoves(queen, board);
             for (queenMoves) |move| {
                 if (!isCheck(move, false)) return false;
             }


### PR DESCRIPTION
## Summary
- track promoted pieces separately in the board representation and ensure empty boards initialise indices for every piece slot
- update move generation, applyMove, and capture helpers to manage promoted pieces while iterating through their move lists
- adjust evaluation and add focused tests covering promotion scenarios and promoted move generation; refresh build script for Zig 0.11 compatibility

## Testing
- zig build test

------
https://chatgpt.com/codex/tasks/task_e_68d16e5caa048324bdb0b94c2a47ac6c