### PR TITLE
Handle promoted pieces correctly

### DIFF
--- a/src/eval.zig
+++ b/src/eval.zig
@@ -30,14 +30,31 @@ pub fn evaluate(board: Board) i32 {
             score += getPiecePositionValue(knight.position, c.KNIGHT_POSITION_TABLE, true);
         }
     }
+    inline for (board.position.whitepieces.PromotedKnight) |knight| {
+        if (knight.position != 0) {
+            score += @as(i32, knight.stdval) * 100;
+            score += getPiecePositionValue(knight.position, c.KNIGHT_POSITION_TABLE, true);
+        }
+    }
     inline for (board.position.whitepieces.Bishop) |bishop| {
+        if (bishop.position != 0) score += @as(i32, bishop.stdval) * 100;
+    }
+    inline for (board.position.whitepieces.PromotedBishop) |bishop| {
         if (bishop.position != 0) score += @as(i32, bishop.stdval) * 100;
     }
     inline for (board.position.whitepieces.Rook) |rook| {
         if (rook.position != 0) score += @as(i32, rook.stdval) * 100;
     }
+    inline for (board.position.whitepieces.PromotedRook) |rook| {
+        if (rook.position != 0) score += @as(i32, rook.stdval) * 100;
+    }
     if (board.position.whitepieces.Queen.position != 0) {
         score += @as(i32, board.position.whitepieces.Queen.stdval) * 100;
+    }
+    inline for (board.position.whitepieces.PromotedQueen) |queen| {
+        if (queen.position != 0) {
+            score += @as(i32, queen.stdval) * 100;
+        }
     }
     if (board.position.whitepieces.King.position != 0) {
         score += @as(i32, board.position.whitepieces.King.stdval) * 100;
@@ -58,14 +75,31 @@ pub fn evaluate(board: Board) i32 {
             score -= getPiecePositionValue(knight.position, c.KNIGHT_POSITION_TABLE, false);
         }
     }
+    inline for (board.position.blackpieces.PromotedKnight) |knight| {
+        if (knight.position != 0) {
+            score -= @as(i32, knight.stdval) * 100;
+            score -= getPiecePositionValue(knight.position, c.KNIGHT_POSITION_TABLE, false);
+        }
+    }
     inline for (board.position.blackpieces.Bishop) |bishop| {
+        if (bishop.position != 0) score -= @as(i32, bishop.stdval) * 100;
+    }
+    inline for (board.position.blackpieces.PromotedBishop) |bishop| {
         if (bishop.position != 0) score -= @as(i32, bishop.stdval) * 100;
     }
     inline for (board.position.blackpieces.Rook) |rook| {
         if (rook.position != 0) score -= @as(i32, rook.stdval) * 100;
     }
+    inline for (board.position.blackpieces.PromotedRook) |rook| {
+        if (rook.position != 0) score -= @as(i32, rook.stdval) * 100;
+    }
     if (board.position.blackpieces.Queen.position != 0) {
         score -= @as(i32, board.position.blackpieces.Queen.stdval) * 100;
+    }
+    inline for (board.position.blackpieces.PromotedQueen) |queen| {
+        if (queen.position != 0) {
+            score -= @as(i32, queen.stdval) * 100;
+        }
     }
     if (board.position.blackpieces.King.position != 0) {
         score -= @as(i32, board.position.blackpieces.King.stdval) * 100;
@@ -73,14 +107,24 @@ pub fn evaluate(board: Board) i32 {
 
     // Additional evaluation factors
     // Bonus for having both bishops
-    if (board.position.whitepieces.Bishop[0].position != 0 and
-        board.position.whitepieces.Bishop[1].position != 0)
-    {
+    var white_bishop_count: u8 = 0;
+    inline for (board.position.whitepieces.Bishop) |bishop| {
+        if (bishop.position != 0) white_bishop_count += 1;
+    }
+    inline for (board.position.whitepieces.PromotedBishop) |bishop| {
+        if (bishop.position != 0) white_bishop_count += 1;
+    }
+    if (white_bishop_count >= 2) {
         score += 50; // Bishop pair bonus
     }
-    if (board.position.blackpieces.Bishop[0].position != 0 and
-        board.position.blackpieces.Bishop[1].position != 0)
-    {
+    var black_bishop_count: u8 = 0;
+    inline for (board.position.blackpieces.Bishop) |bishop| {
+        if (bishop.position != 0) black_bishop_count += 1;
+    }
+    inline for (board.position.blackpieces.PromotedBishop) |bishop| {
+        if (bishop.position != 0) black_bishop_count += 1;
+    }
+    if (black_bishop_count >= 2) {
         score -= 50; // Bishop pair bonus for black
     }
 
@@ -264,13 +308,25 @@ fn countPieces(board: Board, white: bool) u32 {
         for (board.position.whitepieces.Knight) |knight| {
             if (knight.position != 0) count += 1;
         }
+        for (board.position.whitepieces.PromotedKnight) |knight| {
+            if (knight.position != 0) count += 1;
+        }
         for (board.position.whitepieces.Bishop) |bishop| {
+            if (bishop.position != 0) count += 1;
+        }
+        for (board.position.whitepieces.PromotedBishop) |bishop| {
             if (bishop.position != 0) count += 1;
         }
         for (board.position.whitepieces.Rook) |rook| {
             if (rook.position != 0) count += 1;
         }
+        for (board.position.whitepieces.PromotedRook) |rook| {
+            if (rook.position != 0) count += 1;
+        }
         if (board.position.whitepieces.Queen.position != 0) count += 1;
+        for (board.position.whitepieces.PromotedQueen) |queen| {
+            if (queen.position != 0) count += 1;
+        }
         if (board.position.whitepieces.King.position != 0) count += 1;
     } else {
         // Count black pieces
@@ -280,13 +336,25 @@ fn countPieces(board: Board, white: bool) u32 {
         for (board.position.blackpieces.Knight) |knight| {
             if (knight.position != 0) count += 1;
         }
+        for (board.position.blackpieces.PromotedKnight) |knight| {
+            if (knight.position != 0) count += 1;
+        }
         for (board.position.blackpieces.Bishop) |bishop| {
+            if (bishop.position != 0) count += 1;
+        }
+        for (board.position.blackpieces.PromotedBishop) |bishop| {
             if (bishop.position != 0) count += 1;
         }
         for (board.position.blackpieces.Rook) |rook| {
             if (rook.position != 0) count += 1;
         }
+        for (board.position.blackpieces.PromotedRook) |rook| {
+            if (rook.position != 0) count += 1;
+        }
         if (board.position.blackpieces.Queen.position != 0) count += 1;
+        for (board.position.blackpieces.PromotedQueen) |queen| {
+            if (queen.position != 0) count += 1;
+        }
         if (board.position.blackpieces.King.position != 0) count += 1;
     }
 
@@ -332,6 +400,21 @@ test "evaluate empty board" {
     const board = Board{ .position = b.Position.emptyboard() };
     const score = evaluate(board);
     try std.testing.expectEqual(score, 0);
+}
+
+test "evaluate counts promoted queen" {
+    var board = Board{ .position = b.Position.emptyboard() };
+    board.position.whitepieces.Pawn[0].position = c.E7;
+
+    const move = m.Move{
+        .from = c.E7,
+        .to = c.E8,
+        .promotion_piece = 'q',
+    };
+
+    const promoted_board = try m.applyMove(board, move);
+    const score = evaluate(promoted_board);
+    try std.testing.expectEqual(score, 900);
 }
 
 test "evaluate position with multiple missing pieces" {

--- a/src/moves.zig
+++ b/src/moves.zig
@@ -543,10 +543,35 @@ pub fn allvalidmoves(board: b.Board) []b.Board {
                 movecount += 1;
             }
         }
+        for (board.position.whitepieces.PromotedQueen) |q| {
+            if (q.position == 0) continue;
+            const promotedQueenMoves = getValidQueenMoves(q, board);
+            for (promotedQueenMoves) |move| {
+                if (!s.isCheck(move, true)) {
+                    boardCopy = move;
+                    boardCopy.position.sidetomove = next_side;
+                    moves[movecount] = boardCopy;
+                    movecount += 1;
+                }
+            }
+        }
 
         // Rook moves
         var rookMoveCount: usize = 0;
         for (board.position.whitepieces.Rook) |r| {
+            if (r.position == 0) continue;
+            const rookMoves = getValidRookMoves(r, board);
+            rookMoveCount += rookMoves.len;
+            for (rookMoves) |move| {
+                if (!s.isCheck(move, true)) {
+                    boardCopy = move;
+                    boardCopy.position.sidetomove = next_side;
+                    moves[movecount] = boardCopy;
+                    movecount += 1;
+                }
+            }
+        }
+        for (board.position.whitepieces.PromotedRook) |r| {
             if (r.position == 0) continue;
             const rookMoves = getValidRookMoves(r, board);
             rookMoveCount += rookMoves.len;
@@ -575,10 +600,36 @@ pub fn allvalidmoves(board: b.Board) []b.Board {
                 }
             }
         }
+        for (board.position.whitepieces.PromotedBishop) |piece| {
+            if (piece.position == 0) continue;
+            const bishopMoves = getValidBishopMoves(piece, board);
+            bishopMoveCount += bishopMoves.len;
+            for (bishopMoves) |move| {
+                if (!s.isCheck(move, true)) {
+                    boardCopy = move;
+                    boardCopy.position.sidetomove = next_side;
+                    moves[movecount] = boardCopy;
+                    movecount += 1;
+                }
+            }
+        }
 
         // Knight moves
         var knightMoveCount: usize = 0;
         for (board.position.whitepieces.Knight) |k| {
+            if (k.position == 0) continue;
+            const knightMoves = getValidKnightMoves(k, board);
+            knightMoveCount += knightMoves.len;
+            for (knightMoves) |move| {
+                if (!s.isCheck(move, true)) {
+                    boardCopy = move;
+                    boardCopy.position.sidetomove = next_side;
+                    moves[movecount] = boardCopy;
+                    movecount += 1;
+                }
+            }
+        }
+        for (board.position.whitepieces.PromotedKnight) |k| {
             if (k.position == 0) continue;
             const knightMoves = getValidKnightMoves(k, board);
             knightMoveCount += knightMoves.len;
@@ -630,10 +681,35 @@ pub fn allvalidmoves(board: b.Board) []b.Board {
                 movecount += 1;
             }
         }
+        for (board.position.blackpieces.PromotedQueen) |q| {
+            if (q.position == 0) continue;
+            const promotedQueenMoves = getValidQueenMoves(q, board);
+            for (promotedQueenMoves) |move| {
+                if (!s.isCheck(move, false)) {
+                    boardCopy = move;
+                    boardCopy.position.sidetomove = next_side;
+                    moves[movecount] = boardCopy;
+                    movecount += 1;
+                }
+            }
+        }
 
         // Rook moves
         var rookMoveCount: usize = 0;
         for (board.position.blackpieces.Rook) |r| {
+            if (r.position == 0) continue;
+            const rookMoves = getValidRookMoves(r, board);
+            rookMoveCount += rookMoves.len;
+            for (rookMoves) |move| {
+                if (!s.isCheck(move, false)) {
+                    boardCopy = move;
+                    boardCopy.position.sidetomove = next_side;
+                    moves[movecount] = boardCopy;
+                    movecount += 1;
+                }
+            }
+        }
+        for (board.position.blackpieces.PromotedRook) |r| {
             if (r.position == 0) continue;
             const rookMoves = getValidRookMoves(r, board);
             rookMoveCount += rookMoves.len;
@@ -662,10 +738,36 @@ pub fn allvalidmoves(board: b.Board) []b.Board {
                 }
             }
         }
+        for (board.position.blackpieces.PromotedBishop) |piece| {
+            if (piece.position == 0) continue;
+            const bishopMoves = getValidBishopMoves(piece, board);
+            bishopMoveCount += bishopMoves.len;
+            for (bishopMoves) |move| {
+                if (!s.isCheck(move, false)) {
+                    boardCopy = move;
+                    boardCopy.position.sidetomove = next_side;
+                    moves[movecount] = boardCopy;
+                    movecount += 1;
+                }
+            }
+        }
 
         // Knight moves
         var knightMoveCount: usize = 0;
         for (board.position.blackpieces.Knight) |k| {
+            if (k.position == 0) continue;
+            const knightMoves = getValidKnightMoves(k, board);
+            knightMoveCount += knightMoves.len;
+            for (knightMoves) |move| {
+                if (!s.isCheck(move, false)) {
+                    boardCopy = move;
+                    boardCopy.position.sidetomove = next_side;
+                    moves[movecount] = boardCopy;
+                    movecount += 1;
+                }
+            }
+        }
+        for (board.position.blackpieces.PromotedKnight) |k| {
             if (k.position == 0) continue;
             const knightMoves = getValidKnightMoves(k, board);
             knightMoveCount += knightMoves.len;
@@ -761,77 +863,66 @@ pub fn applyMove(board: b.Board, move: Move) !b.Board {
 
     // Find the matching move in valid moves
     for (valid_moves) |valid_move| {
-        // Find the piece that moved by comparing board states
-        var found_piece_pos: u64 = 0;
+        var from_piece_found = false;
 
-        // Check white pieces
-        inline for (std.meta.fields(@TypeOf(valid_move.position.whitepieces))) |field| {
-            const old_piece = @field(board.position.whitepieces, field.name);
-            const new_piece = @field(valid_move.position.whitepieces, field.name);
-
-            if (@TypeOf(old_piece) == b.Piece) {
-                if (old_piece.position == move.from) {
-                    found_piece_pos = new_piece.position;
-                }
-            } else if (@TypeOf(old_piece) == [2]b.Piece or @TypeOf(old_piece) == [8]b.Piece) {
-                for (old_piece, 0..) |p, i| {
-                    if (p.position == move.from) {
-                        found_piece_pos = new_piece[i].position;
-                    }
-                }
-            }
-        }
-
-        // Check black pieces if we haven't found the move
-        if (found_piece_pos == 0) {
-            inline for (std.meta.fields(@TypeOf(valid_move.position.blackpieces))) |field| {
-                const old_piece = @field(board.position.blackpieces, field.name);
-                const new_piece = @field(valid_move.position.blackpieces, field.name);
+        if (piece.color == 0) {
+            inline for (std.meta.fields(@TypeOf(valid_move.position.whitepieces))) |field| {
+                const old_piece = @field(board.position.whitepieces, field.name);
 
                 if (@TypeOf(old_piece) == b.Piece) {
                     if (old_piece.position == move.from) {
-                        found_piece_pos = new_piece.position;
+                        from_piece_found = true;
                     }
                 } else if (@TypeOf(old_piece) == [2]b.Piece or @TypeOf(old_piece) == [8]b.Piece) {
-                    for (old_piece, 0..) |p, i| {
+                    for (old_piece) |p| {
                         if (p.position == move.from) {
-                            found_piece_pos = new_piece[i].position;
+                            from_piece_found = true;
+                        }
+                    }
+                }
+            }
+        } else {
+            inline for (std.meta.fields(@TypeOf(valid_move.position.blackpieces))) |field| {
+                const old_piece = @field(board.position.blackpieces, field.name);
+
+                if (@TypeOf(old_piece) == b.Piece) {
+                    if (old_piece.position == move.from) {
+                        from_piece_found = true;
+                    }
+                } else if (@TypeOf(old_piece) == [2]b.Piece or @TypeOf(old_piece) == [8]b.Piece) {
+                    for (old_piece) |p| {
+                        if (p.position == move.from) {
+                            from_piece_found = true;
                         }
                     }
                 }
             }
         }
 
-        // If this valid move matches our input move, return it
+        if (!from_piece_found) continue;
+
         var result = valid_move;
-        if (found_piece_pos == move.to) {
-            // Handle promotion if specified
-            if (move.promotion_piece) |promotion| {
-                // Find the pawn that was promoted and update its representation
-                if (board.position.sidetomove == 0) {
-                    // White pawn promotion
-                    for (&result.position.whitepieces.Pawn) |*p| {
-                        if (p.position == move.to) {
-                            p.representation = std.ascii.toUpper(promotion);
-                            break;
-                        }
-                    }
-                } else {
-                    // Black pawn promotion
-                    for (&result.position.blackpieces.Pawn) |*p| {
-                        if (p.position == move.to) {
-                            p.representation = promotion;
-                            break;
-                        }
-                    }
-                }
-                //  update side to move
-                result.position.sidetomove = 1 - board.position.sidetomove;
-                return result;
+        const destination_piece = board_helpers.piecefromlocation(move.to, result);
+        if (destination_piece.position != move.to) continue;
+        if (destination_piece.color != piece.color) continue;
+
+        const from_after = board_helpers.piecefromlocation(move.from, result);
+        if (from_after.position != 0) continue;
+
+        if (move.promotion_piece) |promotion| {
+            const expected = if (piece.color == 0)
+                std.ascii.toUpper(promotion)
+            else
+                std.ascii.toLower(promotion);
+            if (destination_piece.representation != expected) {
+                continue;
             }
-            result.position.sidetomove = 1 - board.position.sidetomove;
-            return result;
+        } else if (destination_piece.representation != piece.representation) {
+            continue;
         }
+
+        result.position.sidetomove = 1 - board.position.sidetomove;
+        return result;
     }
 
     return error.InvalidMove;
@@ -878,8 +969,9 @@ test "applyMove pawn promotion" {
     };
 
     const new_board = try applyMove(board, move);
-    try std.testing.expectEqual(new_board.position.whitepieces.Pawn[0].position, c.E8);
-    try std.testing.expectEqual(new_board.position.whitepieces.Pawn[0].representation, 'Q');
+    try std.testing.expectEqual(new_board.position.whitepieces.Pawn[0].position, 0);
+    const promoted = board_helpers.piecefromlocation(c.E8, new_board);
+    try std.testing.expectEqual(promoted.representation, 'Q');
 }
 
 test "applyMove invalid move" {

--- a/src/moves/bishop.zig
+++ b/src/moves/bishop.zig
@@ -6,26 +6,8 @@ pub fn getValidBishopMoves(piece: b.Piece, board: b.Board) []b.Board {
     const bitmap: u64 = board_helpers.bitmapfromboard(board);
     var moves: [256]b.Board = undefined;
     var possiblemoves: usize = 0;
-    var index: usize = 0;
 
     const next_side: u8 = if (board.position.sidetomove == 0) 1 else 0;
-
-    // Find which bishop we're moving
-    if (piece.color == 0) {
-        for (board.position.whitepieces.Bishop, 0..) |item, loopidx| {
-            if (item.position == piece.position) {
-                index = loopidx;
-                break;
-            }
-        }
-    } else {
-        for (board.position.blackpieces.Bishop, 0..) |item, loopidx| {
-            if (item.position == piece.position) {
-                index = loopidx;
-                break;
-            }
-        }
-    }
 
     const row = board_helpers.rowfrombitmap(piece.position);
     const col = board_helpers.colfrombitmap(piece.position);
@@ -43,11 +25,7 @@ pub fn getValidBishopMoves(piece: b.Piece, board: b.Board) []b.Board {
         // Check if target square is empty
         if (bitmap & newpos == 0) {
             var newBoard = b.Board{ .position = board.position };
-            if (piece.color == 0) {
-                newBoard.position.whitepieces.Bishop[index].position = newpos;
-            } else {
-                newBoard.position.blackpieces.Bishop[index].position = newpos;
-            }
+            board_helpers.movePiece(&newBoard.position, piece, newpos);
             newBoard.position.sidetomove = next_side;
             moves[possiblemoves] = newBoard;
             possiblemoves += 1;
@@ -59,11 +37,7 @@ pub fn getValidBishopMoves(piece: b.Piece, board: b.Board) []b.Board {
                     board_helpers.captureblackpiece(newpos, b.Board{ .position = board.position })
                 else
                     board_helpers.capturewhitepiece(newpos, b.Board{ .position = board.position });
-                if (piece.color == 0) {
-                    newBoard.position.whitepieces.Bishop[index].position = newpos;
-                } else {
-                    newBoard.position.blackpieces.Bishop[index].position = newpos;
-                }
+                board_helpers.movePiece(&newBoard.position, piece, newpos);
                 newBoard.position.sidetomove = next_side;
                 moves[possiblemoves] = newBoard;
                 possiblemoves += 1;
@@ -81,11 +55,7 @@ pub fn getValidBishopMoves(piece: b.Piece, board: b.Board) []b.Board {
 
         if (bitmap & newpos == 0) {
             var newBoard = b.Board{ .position = board.position };
-            if (piece.color == 0) {
-                newBoard.position.whitepieces.Bishop[index].position = newpos;
-            } else {
-                newBoard.position.blackpieces.Bishop[index].position = newpos;
-            }
+            board_helpers.movePiece(&newBoard.position, piece, newpos);
             newBoard.position.sidetomove = next_side;
             moves[possiblemoves] = newBoard;
             possiblemoves += 1;
@@ -96,11 +66,7 @@ pub fn getValidBishopMoves(piece: b.Piece, board: b.Board) []b.Board {
                     board_helpers.captureblackpiece(newpos, b.Board{ .position = board.position })
                 else
                     board_helpers.capturewhitepiece(newpos, b.Board{ .position = board.position });
-                if (piece.color == 0) {
-                    newBoard.position.whitepieces.Bishop[index].position = newpos;
-                } else {
-                    newBoard.position.blackpieces.Bishop[index].position = newpos;
-                }
+                board_helpers.movePiece(&newBoard.position, piece, newpos);
                 newBoard.position.sidetomove = next_side;
                 moves[possiblemoves] = newBoard;
                 possiblemoves += 1;
@@ -118,11 +84,7 @@ pub fn getValidBishopMoves(piece: b.Piece, board: b.Board) []b.Board {
 
         if (bitmap & newpos == 0) {
             var newBoard = b.Board{ .position = board.position };
-            if (piece.color == 0) {
-                newBoard.position.whitepieces.Bishop[index].position = newpos;
-            } else {
-                newBoard.position.blackpieces.Bishop[index].position = newpos;
-            }
+            board_helpers.movePiece(&newBoard.position, piece, newpos);
             newBoard.position.sidetomove = next_side;
             moves[possiblemoves] = newBoard;
             possiblemoves += 1;
@@ -133,11 +95,7 @@ pub fn getValidBishopMoves(piece: b.Piece, board: b.Board) []b.Board {
                     board_helpers.captureblackpiece(newpos, b.Board{ .position = board.position })
                 else
                     board_helpers.capturewhitepiece(newpos, b.Board{ .position = board.position });
-                if (piece.color == 0) {
-                    newBoard.position.whitepieces.Bishop[index].position = newpos;
-                } else {
-                    newBoard.position.blackpieces.Bishop[index].position = newpos;
-                }
+                board_helpers.movePiece(&newBoard.position, piece, newpos);
                 newBoard.position.sidetomove = next_side;
                 moves[possiblemoves] = newBoard;
                 possiblemoves += 1;
@@ -155,11 +113,7 @@ pub fn getValidBishopMoves(piece: b.Piece, board: b.Board) []b.Board {
 
         if (bitmap & newpos == 0) {
             var newBoard = b.Board{ .position = board.position };
-            if (piece.color == 0) {
-                newBoard.position.whitepieces.Bishop[index].position = newpos;
-            } else {
-                newBoard.position.blackpieces.Bishop[index].position = newpos;
-            }
+            board_helpers.movePiece(&newBoard.position, piece, newpos);
             newBoard.position.sidetomove = next_side;
             moves[possiblemoves] = newBoard;
             possiblemoves += 1;
@@ -170,11 +124,7 @@ pub fn getValidBishopMoves(piece: b.Piece, board: b.Board) []b.Board {
                     board_helpers.captureblackpiece(newpos, b.Board{ .position = board.position })
                 else
                     board_helpers.capturewhitepiece(newpos, b.Board{ .position = board.position });
-                if (piece.color == 0) {
-                    newBoard.position.whitepieces.Bishop[index].position = newpos;
-                } else {
-                    newBoard.position.blackpieces.Bishop[index].position = newpos;
-                }
+                board_helpers.movePiece(&newBoard.position, piece, newpos);
                 newBoard.position.sidetomove = next_side;
                 moves[possiblemoves] = newBoard;
                 possiblemoves += 1;

--- a/src/moves/knight.zig
+++ b/src/moves/knight.zig
@@ -10,29 +10,7 @@ pub fn getValidKnightMoves(piece: b.Piece, board: b.Board) []b.Board {
 
     const next_side: u8 = if (board.position.sidetomove == 0) 1 else 0;
 
-    // Find the correct index for the knight
-    var index: u8 = 0;
-    if (piece.color == 0) {
-        // White knight
-        if (board.position.whitepieces.Knight[0].position == piece.position) {
-            index = 0;
-        } else if (board.position.whitepieces.Knight[1].position == piece.position) {
-            index = 1;
-        } else {
-            // Knight not found, return empty array
-            return moves[0..0];
-        }
-    } else {
-        // Black knight
-        if (board.position.blackpieces.Knight[0].position == piece.position) {
-            index = 0;
-        } else if (board.position.blackpieces.Knight[1].position == piece.position) {
-            index = 1;
-        } else {
-            // Knight not found, return empty array
-            return moves[0..0];
-        }
-    }
+    if (piece.position == 0) return moves[0..0];
 
     // Define all possible knight move shifts
     // These represent the 8 possible L-shaped moves a knight can make
@@ -66,11 +44,7 @@ pub fn getValidKnightMoves(piece: b.Piece, board: b.Board) []b.Board {
         if (bitmap & newpos == 0) {
             // Empty square - add move
             var newBoard = b.Board{ .position = board.position };
-            if (piece.color == 0) {
-                newBoard.position.whitepieces.Knight[index].position = newpos;
-            } else {
-                newBoard.position.blackpieces.Knight[index].position = newpos;
-            }
+            board_helpers.movePiece(&newBoard.position, piece, newpos);
             newBoard.position.sidetomove = next_side;
             moves[possiblemoves] = newBoard;
             possiblemoves += 1;
@@ -84,11 +58,7 @@ pub fn getValidKnightMoves(piece: b.Piece, board: b.Board) []b.Board {
                 else
                     board_helpers.capturewhitepiece(newpos, b.Board{ .position = board.position });
 
-                if (piece.color == 0) {
-                    newBoard.position.whitepieces.Knight[index].position = newpos;
-                } else {
-                    newBoard.position.blackpieces.Knight[index].position = newpos;
-                }
+                board_helpers.movePiece(&newBoard.position, piece, newpos);
                 newBoard.position.sidetomove = next_side;
                 moves[possiblemoves] = newBoard;
                 possiblemoves += 1;

--- a/src/moves/queen.zig
+++ b/src/moves/queen.zig
@@ -12,7 +12,6 @@ pub fn getValidQueenMoves(piece: b.Piece, board: b.Board) []b.Board {
     const shifts = [7]u6{ 1, 2, 3, 4, 5, 6, 7 };
     const row: u64 = board_helpers.rowfrombitmap(queen_piece.position);
     const col: u64 = board_helpers.colfrombitmap(queen_piece.position);
-    var newqueen: b.Piece = queen_piece;
     var testpiece: b.Piece = undefined;
     const next_side: u8 = if (board.position.sidetomove == 0) 1 else 0;
 
@@ -25,29 +24,21 @@ pub fn getValidQueenMoves(piece: b.Piece, board: b.Board) []b.Board {
 
         if (bitmap & newpos == 0) {
             // Empty square
-            newqueen.position = newpos;
             moves[possiblemoves] = b.Board{ .position = board.position };
             moves[possiblemoves].position.sidetomove = next_side;
-            if (queen_piece.color == 0) {
-                moves[possiblemoves].position.whitepieces.Queen = newqueen;
-            } else {
-                moves[possiblemoves].position.blackpieces.Queen = newqueen;
-            }
+            board_helpers.movePiece(&moves[possiblemoves].position, queen_piece, newpos);
             possiblemoves += 1;
         } else {
             // Check for capture
             testpiece = board_helpers.piecefromlocation(newpos, board);
             if (testpiece.color != queen_piece.color) {
-                newqueen.position = newpos;
                 if (queen_piece.color == 0) {
                     moves[possiblemoves] = board_helpers.captureblackpiece(newpos, b.Board{ .position = board.position });
-                    moves[possiblemoves].position.sidetomove = next_side;
-                    moves[possiblemoves].position.whitepieces.Queen = newqueen;
                 } else {
                     moves[possiblemoves] = board_helpers.capturewhitepiece(newpos, b.Board{ .position = board.position });
-                    moves[possiblemoves].position.sidetomove = next_side;
-                    moves[possiblemoves].position.blackpieces.Queen = newqueen;
                 }
+                board_helpers.movePiece(&moves[possiblemoves].position, queen_piece, newpos);
+                moves[possiblemoves].position.sidetomove = next_side;
                 possiblemoves += 1;
             }
             break;
@@ -62,29 +53,21 @@ pub fn getValidQueenMoves(piece: b.Piece, board: b.Board) []b.Board {
 
         if (bitmap & newpos == 0) {
             // Empty square
-            newqueen.position = newpos;
             moves[possiblemoves] = b.Board{ .position = board.position };
             moves[possiblemoves].position.sidetomove = next_side;
-            if (queen_piece.color == 0) {
-                moves[possiblemoves].position.whitepieces.Queen = newqueen;
-            } else {
-                moves[possiblemoves].position.blackpieces.Queen = newqueen;
-            }
+            board_helpers.movePiece(&moves[possiblemoves].position, queen_piece, newpos);
             possiblemoves += 1;
         } else {
             // Check for capture
             testpiece = board_helpers.piecefromlocation(newpos, board);
             if (testpiece.color != queen_piece.color) {
-                newqueen.position = newpos;
                 if (queen_piece.color == 0) {
                     moves[possiblemoves] = board_helpers.captureblackpiece(newpos, b.Board{ .position = board.position });
-                    moves[possiblemoves].position.sidetomove = next_side;
-                    moves[possiblemoves].position.whitepieces.Queen = newqueen;
                 } else {
                     moves[possiblemoves] = board_helpers.capturewhitepiece(newpos, b.Board{ .position = board.position });
-                    moves[possiblemoves].position.sidetomove = next_side;
-                    moves[possiblemoves].position.blackpieces.Queen = newqueen;
                 }
+                board_helpers.movePiece(&moves[possiblemoves].position, queen_piece, newpos);
+                moves[possiblemoves].position.sidetomove = next_side;
                 possiblemoves += 1;
             }
             break;
@@ -99,29 +82,21 @@ pub fn getValidQueenMoves(piece: b.Piece, board: b.Board) []b.Board {
 
         if (bitmap & newpos == 0) {
             // Empty square
-            newqueen.position = newpos;
             moves[possiblemoves] = b.Board{ .position = board.position };
             moves[possiblemoves].position.sidetomove = next_side;
-            if (queen_piece.color == 0) {
-                moves[possiblemoves].position.whitepieces.Queen = newqueen;
-            } else {
-                moves[possiblemoves].position.blackpieces.Queen = newqueen;
-            }
+            board_helpers.movePiece(&moves[possiblemoves].position, queen_piece, newpos);
             possiblemoves += 1;
         } else {
             // Check for capture
             testpiece = board_helpers.piecefromlocation(newpos, board);
             if (testpiece.color != queen_piece.color) {
-                newqueen.position = newpos;
                 if (queen_piece.color == 0) {
                     moves[possiblemoves] = board_helpers.captureblackpiece(newpos, b.Board{ .position = board.position });
-                    moves[possiblemoves].position.sidetomove = next_side;
-                    moves[possiblemoves].position.whitepieces.Queen = newqueen;
                 } else {
                     moves[possiblemoves] = board_helpers.capturewhitepiece(newpos, b.Board{ .position = board.position });
-                    moves[possiblemoves].position.sidetomove = next_side;
-                    moves[possiblemoves].position.blackpieces.Queen = newqueen;
                 }
+                board_helpers.movePiece(&moves[possiblemoves].position, queen_piece, newpos);
+                moves[possiblemoves].position.sidetomove = next_side;
                 possiblemoves += 1;
             }
             break;
@@ -136,29 +111,21 @@ pub fn getValidQueenMoves(piece: b.Piece, board: b.Board) []b.Board {
 
         if (bitmap & newpos == 0) {
             // Empty square
-            newqueen.position = newpos;
             moves[possiblemoves] = b.Board{ .position = board.position };
             moves[possiblemoves].position.sidetomove = next_side;
-            if (queen_piece.color == 0) {
-                moves[possiblemoves].position.whitepieces.Queen = newqueen;
-            } else {
-                moves[possiblemoves].position.blackpieces.Queen = newqueen;
-            }
+            board_helpers.movePiece(&moves[possiblemoves].position, queen_piece, newpos);
             possiblemoves += 1;
         } else {
             // Check for capture
             testpiece = board_helpers.piecefromlocation(newpos, board);
             if (testpiece.color != queen_piece.color) {
-                newqueen.position = newpos;
                 if (queen_piece.color == 0) {
                     moves[possiblemoves] = board_helpers.captureblackpiece(newpos, b.Board{ .position = board.position });
-                    moves[possiblemoves].position.sidetomove = next_side;
-                    moves[possiblemoves].position.whitepieces.Queen = newqueen;
                 } else {
                     moves[possiblemoves] = board_helpers.capturewhitepiece(newpos, b.Board{ .position = board.position });
-                    moves[possiblemoves].position.sidetomove = next_side;
-                    moves[possiblemoves].position.blackpieces.Queen = newqueen;
                 }
+                board_helpers.movePiece(&moves[possiblemoves].position, queen_piece, newpos);
+                moves[possiblemoves].position.sidetomove = next_side;
                 possiblemoves += 1;
             }
             break;
@@ -174,29 +141,21 @@ pub fn getValidQueenMoves(piece: b.Piece, board: b.Board) []b.Board {
 
         if (bitmap & newpos == 0) {
             // Empty square
-            newqueen.position = newpos;
             moves[possiblemoves] = b.Board{ .position = board.position };
             moves[possiblemoves].position.sidetomove = next_side;
-            if (queen_piece.color == 0) {
-                moves[possiblemoves].position.whitepieces.Queen = newqueen;
-            } else {
-                moves[possiblemoves].position.blackpieces.Queen = newqueen;
-            }
+            board_helpers.movePiece(&moves[possiblemoves].position, queen_piece, newpos);
             possiblemoves += 1;
         } else {
             // Check for capture
             testpiece = board_helpers.piecefromlocation(newpos, board);
             if (testpiece.color != queen_piece.color) {
-                newqueen.position = newpos;
                 if (queen_piece.color == 0) {
                     moves[possiblemoves] = board_helpers.captureblackpiece(newpos, b.Board{ .position = board.position });
-                    moves[possiblemoves].position.sidetomove = next_side;
-                    moves[possiblemoves].position.whitepieces.Queen = newqueen;
                 } else {
                     moves[possiblemoves] = board_helpers.capturewhitepiece(newpos, b.Board{ .position = board.position });
-                    moves[possiblemoves].position.sidetomove = next_side;
-                    moves[possiblemoves].position.blackpieces.Queen = newqueen;
                 }
+                board_helpers.movePiece(&moves[possiblemoves].position, queen_piece, newpos);
+                moves[possiblemoves].position.sidetomove = next_side;
                 possiblemoves += 1;
             }
             break;
@@ -211,29 +170,21 @@ pub fn getValidQueenMoves(piece: b.Piece, board: b.Board) []b.Board {
 
         if (bitmap & newpos == 0) {
             // Empty square
-            newqueen.position = newpos;
             moves[possiblemoves] = b.Board{ .position = board.position };
             moves[possiblemoves].position.sidetomove = next_side;
-            if (queen_piece.color == 0) {
-                moves[possiblemoves].position.whitepieces.Queen = newqueen;
-            } else {
-                moves[possiblemoves].position.blackpieces.Queen = newqueen;
-            }
+            board_helpers.movePiece(&moves[possiblemoves].position, queen_piece, newpos);
             possiblemoves += 1;
         } else {
             // Check for capture
             testpiece = board_helpers.piecefromlocation(newpos, board);
             if (testpiece.color != queen_piece.color) {
-                newqueen.position = newpos;
                 if (queen_piece.color == 0) {
                     moves[possiblemoves] = board_helpers.captureblackpiece(newpos, b.Board{ .position = board.position });
-                    moves[possiblemoves].position.sidetomove = next_side;
-                    moves[possiblemoves].position.whitepieces.Queen = newqueen;
                 } else {
                     moves[possiblemoves] = board_helpers.capturewhitepiece(newpos, b.Board{ .position = board.position });
-                    moves[possiblemoves].position.sidetomove = next_side;
-                    moves[possiblemoves].position.blackpieces.Queen = newqueen;
                 }
+                board_helpers.movePiece(&moves[possiblemoves].position, queen_piece, newpos);
+                moves[possiblemoves].position.sidetomove = next_side;
                 possiblemoves += 1;
             }
             break;
@@ -247,30 +198,21 @@ pub fn getValidQueenMoves(piece: b.Piece, board: b.Board) []b.Board {
         if (newpos == 0) break;
 
         if (bitmap & newpos == 0) {
-            // Empty square
-            newqueen.position = newpos;
             moves[possiblemoves] = b.Board{ .position = board.position };
             moves[possiblemoves].position.sidetomove = next_side;
-            if (queen_piece.color == 0) {
-                moves[possiblemoves].position.whitepieces.Queen = newqueen;
-            } else {
-                moves[possiblemoves].position.blackpieces.Queen = newqueen;
-            }
+            board_helpers.movePiece(&moves[possiblemoves].position, queen_piece, newpos);
             possiblemoves += 1;
         } else {
             // Check for capture
             testpiece = board_helpers.piecefromlocation(newpos, board);
             if (testpiece.color != queen_piece.color) {
-                newqueen.position = newpos;
                 if (queen_piece.color == 0) {
                     moves[possiblemoves] = board_helpers.captureblackpiece(newpos, b.Board{ .position = board.position });
-                    moves[possiblemoves].position.sidetomove = next_side;
-                    moves[possiblemoves].position.whitepieces.Queen = newqueen;
                 } else {
                     moves[possiblemoves] = board_helpers.capturewhitepiece(newpos, b.Board{ .position = board.position });
-                    moves[possiblemoves].position.sidetomove = next_side;
-                    moves[possiblemoves].position.blackpieces.Queen = newqueen;
                 }
+                board_helpers.movePiece(&moves[possiblemoves].position, queen_piece, newpos);
+                moves[possiblemoves].position.sidetomove = next_side;
                 possiblemoves += 1;
             }
             break;
@@ -284,27 +226,19 @@ pub fn getValidQueenMoves(piece: b.Piece, board: b.Board) []b.Board {
         if (newpos == 0) break;
 
         if (bitmap & newpos == 0) {
-            // Empty square
-            newqueen.position = newpos;
             moves[possiblemoves] = b.Board{ .position = board.position };
-            if (queen_piece.color == 0) {
-                moves[possiblemoves].position.whitepieces.Queen = newqueen;
-            } else {
-                moves[possiblemoves].position.blackpieces.Queen = newqueen;
-            }
+            board_helpers.movePiece(&moves[possiblemoves].position, queen_piece, newpos);
             possiblemoves += 1;
         } else {
             // Check for capture
             testpiece = board_helpers.piecefromlocation(newpos, board);
             if (testpiece.color != queen_piece.color) {
-                newqueen.position = newpos;
                 if (queen_piece.color == 0) {
                     moves[possiblemoves] = board_helpers.captureblackpiece(newpos, b.Board{ .position = board.position });
-                    moves[possiblemoves].position.whitepieces.Queen = newqueen;
                 } else {
                     moves[possiblemoves] = board_helpers.capturewhitepiece(newpos, b.Board{ .position = board.position });
-                    moves[possiblemoves].position.blackpieces.Queen = newqueen;
                 }
+                board_helpers.movePiece(&moves[possiblemoves].position, queen_piece, newpos);
                 possiblemoves += 1;
             }
             break;

--- a/src/moves/rook.zig
+++ b/src/moves/rook.zig
@@ -7,27 +7,9 @@ pub fn getValidRookMoves(piece: b.Piece, board: b.Board) []b.Board {
     const bitmap: u64 = board_helpers.bitmapfromboard(board);
     var moves: [256]b.Board = undefined;
     var possiblemoves: usize = 0;
-    var index: usize = 0; // Initialize with a default value
 
     const next_side: u8 = if (board.position.sidetomove == 0) 1 else 0;
     const from_square = piece.position;
-
-    // Find which rook we're moving
-    if (piece.color == 0) {
-        for (board.position.whitepieces.Rook, 0..) |item, loopidx| {
-            if (item.position == piece.position) {
-                index = loopidx;
-                break;
-            }
-        }
-    } else {
-        for (board.position.blackpieces.Rook, 0..) |item, loopidx| {
-            if (item.position == piece.position) {
-                index = loopidx;
-                break;
-            }
-        }
-    }
 
     const row: u64 = board_helpers.rowfrombitmap(piece.position);
     const col: u64 = board_helpers.colfrombitmap(piece.position);
@@ -61,20 +43,19 @@ pub fn getValidRookMoves(piece: b.Piece, board: b.Board) []b.Board {
             if (bitmap & newpos == 0) {
                 var newBoard = b.Board{ .position = board.position };
                 if (piece.color == 0) {
-                    newBoard.position.whitepieces.Rook[index].position = newpos;
                     if (from_square == c.A1) {
                         newBoard.position.canCastleWhiteQueenside = false;
                     } else if (from_square == c.H1) {
                         newBoard.position.canCastleWhiteKingside = false;
                     }
                 } else {
-                    newBoard.position.blackpieces.Rook[index].position = newpos;
                     if (from_square == c.A8) {
                         newBoard.position.canCastleBlackQueenside = false;
                     } else if (from_square == c.H8) {
                         newBoard.position.canCastleBlackKingside = false;
                     }
                 }
+                board_helpers.movePiece(&newBoard.position, piece, newpos);
                 newBoard.position.sidetomove = next_side;
                 moves[possiblemoves] = newBoard;
                 possiblemoves += 1;
@@ -88,20 +69,19 @@ pub fn getValidRookMoves(piece: b.Piece, board: b.Board) []b.Board {
                         board_helpers.capturewhitepiece(newpos, b.Board{ .position = board.position });
 
                     if (piece.color == 0) {
-                        newBoard.position.whitepieces.Rook[index].position = newpos;
                         if (from_square == c.A1) {
                             newBoard.position.canCastleWhiteQueenside = false;
                         } else if (from_square == c.H1) {
                             newBoard.position.canCastleWhiteKingside = false;
                         }
                     } else {
-                        newBoard.position.blackpieces.Rook[index].position = newpos;
                         if (from_square == c.A8) {
                             newBoard.position.canCastleBlackQueenside = false;
                         } else if (from_square == c.H8) {
                             newBoard.position.canCastleBlackKingside = false;
                         }
                     }
+                    board_helpers.movePiece(&newBoard.position, piece, newpos);
                     newBoard.position.sidetomove = next_side;
                     moves[possiblemoves] = newBoard;
                     possiblemoves += 1;

--- a/src/state.zig
+++ b/src/state.zig
@@ -54,6 +54,23 @@ pub fn isCheck(board: b.Board, isWhite: bool) bool {
                 }
             }
         }
+        for (board.position.blackpieces.PromotedKnight) |knight| {
+            if (knight.position == 0) continue;
+            for (knightShifts) |move| {
+                if (kingPosition & move.mask == 0) continue;
+
+                const candidate = if (move.shift > 0)
+                    kingPosition << @as(u6, @intCast(move.shift))
+                else
+                    kingPosition >> @as(u6, @intCast(-move.shift));
+
+                if (candidate == 0) continue;
+
+                if (candidate == knight.position) {
+                    return true;
+                }
+            }
+        }
 
         // Check black bishops
         for (board.position.blackpieces.Bishop) |bishop| {
@@ -64,6 +81,15 @@ pub fn isCheck(board: b.Board, isWhite: bool) bool {
                 if (move.position.blackpieces.Bishop[0].position == kingPosition or
                     move.position.blackpieces.Bishop[1].position == kingPosition)
                 {
+                    return true;
+                }
+            }
+        }
+        for (board.position.blackpieces.PromotedBishop) |bishop| {
+            if (bishop.position == 0) continue;
+            const moves = m.getValidBishopMoves(bishop, board);
+            for (moves) |move| {
+                if (move.position.blackpieces.PromotedBishop[bishop.index].position == kingPosition) {
                     return true;
                 }
             }
@@ -82,6 +108,15 @@ pub fn isCheck(board: b.Board, isWhite: bool) bool {
                 }
             }
         }
+        for (board.position.blackpieces.PromotedRook) |rook| {
+            if (rook.position == 0) continue;
+            const moves = m.getValidRookMoves(rook, board);
+            for (moves) |move| {
+                if (move.position.blackpieces.PromotedRook[rook.index].position == kingPosition) {
+                    return true;
+                }
+            }
+        }
 
         // Check black queen
         if (board.position.blackpieces.Queen.position != 0) {
@@ -89,6 +124,15 @@ pub fn isCheck(board: b.Board, isWhite: bool) bool {
             for (moves) |move| {
                 // Check if any of the queen's valid moves can reach the king's position
                 if (move.position.blackpieces.Queen.position == kingPosition) {
+                    return true;
+                }
+            }
+        }
+        for (board.position.blackpieces.PromotedQueen) |queen| {
+            if (queen.position == 0) continue;
+            const moves = m.ValidQueenMoves(queen, board);
+            for (moves) |move| {
+                if (move.position.blackpieces.PromotedQueen[queen.index].position == kingPosition) {
                     return true;
                 }
             }
@@ -126,6 +170,23 @@ pub fn isCheck(board: b.Board, isWhite: bool) bool {
                 }
             }
         }
+        for (board.position.whitepieces.PromotedKnight) |knight| {
+            if (knight.position == 0) continue;
+            for (knightShifts) |move| {
+                if (kingPosition & move.mask == 0) continue;
+
+                const candidate = if (move.shift > 0)
+                    kingPosition << @as(u6, @intCast(move.shift))
+                else
+                    kingPosition >> @as(u6, @intCast(-move.shift));
+
+                if (candidate == 0) continue;
+
+                if (candidate == knight.position) {
+                    return true;
+                }
+            }
+        }
 
         // Check white bishops
         for (board.position.whitepieces.Bishop) |bishop| {
@@ -136,6 +197,15 @@ pub fn isCheck(board: b.Board, isWhite: bool) bool {
                 if (move.position.whitepieces.Bishop[0].position == kingPosition or
                     move.position.whitepieces.Bishop[1].position == kingPosition)
                 {
+                    return true;
+                }
+            }
+        }
+        for (board.position.whitepieces.PromotedBishop) |bishop| {
+            if (bishop.position == 0) continue;
+            const moves = m.getValidBishopMoves(bishop, board);
+            for (moves) |move| {
+                if (move.position.whitepieces.PromotedBishop[bishop.index].position == kingPosition) {
                     return true;
                 }
             }
@@ -154,6 +224,15 @@ pub fn isCheck(board: b.Board, isWhite: bool) bool {
                 }
             }
         }
+        for (board.position.whitepieces.PromotedRook) |rook| {
+            if (rook.position == 0) continue;
+            const moves = m.getValidRookMoves(rook, board);
+            for (moves) |move| {
+                if (move.position.whitepieces.PromotedRook[rook.index].position == kingPosition) {
+                    return true;
+                }
+            }
+        }
 
         // Check white queen
         if (board.position.whitepieces.Queen.position != 0) {
@@ -161,6 +240,15 @@ pub fn isCheck(board: b.Board, isWhite: bool) bool {
             for (moves) |move| {
                 // Check if any of the queen's valid moves can reach the king's position
                 if (move.position.whitepieces.Queen.position == kingPosition) {
+                    return true;
+                }
+            }
+        }
+        for (board.position.whitepieces.PromotedQueen) |queen| {
+            if (queen.position == 0) continue;
+            const moves = m.ValidQueenMoves(queen, board);
+            for (moves) |move| {
+                if (move.position.whitepieces.PromotedQueen[queen.index].position == kingPosition) {
                     return true;
                 }
             }


### PR DESCRIPTION
## Summary
- track promoted pieces separately in the board representation and helper utilities
- update move generation, applyMove, and evaluation to handle promoted pieces
- extend tests around promotions for legal moves and scoring

## Testing
- zig build test

------
https://chatgpt.com/codex/tasks/task_e_68d16e5caa048324bdb0b94c2a47ac6c