### PR TITLE
Pin CI to Zig 0.15.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,10 +13,14 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: goto-bus-stop/setup-zig@v2
+        with:
+          zig-version: 0.15.1
       - run: zig test src/lib.zig
   lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: goto-bus-stop/setup-zig@v2
+        with:
+          zig-version: 0.15.1
       - run: zig fmt --check src


### PR DESCRIPTION
## Summary
- configure the CI workflow to install Zig 0.15.1 for both test and lint jobs

## Testing
- ./zig-x86_64-linux-0.15.1/zig test src/lib.zig
- ./zig-x86_64-linux-0.15.1/zig fmt --check src

------
https://chatgpt.com/codex/tasks/task_e_68d1872e58a48324b64088e82256e896