### PR TITLE
Update UCI protocol for Zig 0.15

### DIFF
--- a/src/uci/protocol.zig
+++ b/src/uci/protocol.zig
@@ -15,7 +15,7 @@ pub const UciProtocol = struct {
     test_writer: ?std.ArrayList(u8).Writer = null,
     current_board: b.Board = b.Board{ .position = b.Position.init() },
     search_in_progress: bool = false,
-    allocated_strings: std.ArrayList([]u8) = undefined,
+    allocated_strings: std.ArrayList([]u8) = std.ArrayList([]u8).empty,
     move_overhead: u32 = 10,
     threads: u32 = 1,
     debug_log_file: []const u8 = "",
@@ -45,7 +45,7 @@ pub const UciProtocol = struct {
             .test_writer = null,
             .current_board = b.Board{ .position = b.Position.init() },
             .search_in_progress = false,
-            .allocated_strings = std.ArrayList([]u8).init(allocator),
+            .allocated_strings = std.ArrayList([]u8).empty,
             .move_overhead = 10,
             .threads = 1,
             .debug_log_file = "",
@@ -80,7 +80,7 @@ pub const UciProtocol = struct {
         }
         if (self.debug_mode) {
             const debug_msg = try std.fmt.allocPrint(self.allocator, "info string Searching with depth {d}", .{search_depth});
-            try self.allocated_strings.append(debug_msg);
+            try self.allocated_strings.append(self.allocator, debug_msg);
             try self.respond(debug_msg);
         }
         if (e.findBestMove(self.current_board, search_depth)) |best_move| {
@@ -108,12 +108,12 @@ pub const UciProtocol = struct {
             if (std.mem.eql(u8, pos_type, "startpos")) {
                 board = b.Board{ .position = b.Position.init() };
             } else if (std.mem.eql(u8, pos_type, "fen")) {
-                var fen = std.ArrayList(u8).init(allocator);
-                defer fen.deinit();
+                var fen = std.ArrayList(u8){};
+                defer fen.deinit(allocator);
                 while (iter.next()) |part| {
                     if (std.mem.eql(u8, part, "moves")) break;
-                    try fen.appendSlice(part);
-                    try fen.append(' ');
+                    try fen.appendSlice(allocator, part);
+                    try fen.append(allocator, ' ');
                 }
                 if (fen.items.len > 0) {
                     board = b.Board{ .position = b.parseFen(fen.items) };
@@ -429,7 +429,7 @@ pub const UciProtocol = struct {
                     const search_time = end_time - start_time;
                     const score = e.evaluate(new_board);
                     const info_msg = try std.fmt.allocPrint(self.allocator, "info depth {d} score cp {d} time {d}", .{ max_depth, score, search_time });
-                    try self.allocated_strings.append(info_msg);
+                    try self.allocated_strings.append(self.allocator, info_msg);
                     try self.respond(info_msg);
                     const move = helpers.moveToUci(self.current_board, new_board);
                     var move_str: [10]u8 = undefined;
@@ -441,8 +441,10 @@ pub const UciProtocol = struct {
                     if (self.test_writer) |w| {
                         try w.print("bestmove {s}\n", .{move_str[0..move_len]});
                     } else {
-                        const stdout = std.io.getStdOut().writer();
-                        try stdout.print("bestmove {s}\n", .{move_str[0..move_len]});
+                        var out_buf: [32]u8 = undefined;
+                        const bestmove_line = try std.fmt.bufPrint(&out_buf, "bestmove {s}\n", .{move_str[0..move_len]});
+                        const stdout_file = std.fs.File.stdout();
+                        try stdout_file.writeAll(bestmove_line);
                     }
                 } else {
                     try self.respond("bestmove 0000");
@@ -463,8 +465,10 @@ pub const UciProtocol = struct {
                         if (self.test_writer) |w| {
                             try w.print("bestmove {s}\n", .{move_str[0..move_len]});
                         } else {
-                            const stdout = std.io.getStdOut().writer();
-                            try stdout.print("bestmove {s}\n", .{move_str[0..move_len]});
+                            var out_buf: [32]u8 = undefined;
+                            const bestmove_line = try std.fmt.bufPrint(&out_buf, "bestmove {s}\n", .{move_str[0..move_len]});
+                            const stdout_file = std.fs.File.stdout();
+                            try stdout_file.writeAll(bestmove_line);
                         }
                     } else {
                         try self.respond("bestmove 0000");
@@ -489,18 +493,18 @@ pub const UciProtocol = struct {
     }
 
     pub fn mainLoop(self: *UciProtocol) !void {
-        const stdin = std.io.getStdIn().reader();
-        var buf: [1024]u8 = undefined;
+        var stdin_buffer: [1024]u8 = undefined;
+        var stdin_reader = std.fs.File.stdin().reader(&stdin_buffer);
         while (true) {
-            if (try stdin.readUntilDelimiterOrEof(&buf, '\n')) |line| {
-                if (UciCommand.fromString(line) == .quit) {
-                    try self.processCommand(line);
-                    break;
-                }
+            const line = stdin_reader.interface.takeDelimiterExclusive('\n') catch |err| switch (err) {
+                error.EndOfStream => break,
+                else => return err,
+            };
+            if (UciCommand.fromString(line) == .quit) {
                 try self.processCommand(line);
-            } else {
                 break;
             }
+            try self.processCommand(line);
         }
     }
 
@@ -508,8 +512,9 @@ pub const UciProtocol = struct {
         if (self.test_writer) |w| {
             try w.print("{s}\n", .{msg});
         } else {
-            const stdout = std.io.getStdOut().writer();
-            try stdout.print("{s}\n", .{msg});
+            const stdout_file = std.fs.File.stdout();
+            try stdout_file.writeAll(msg);
+            try stdout_file.writeAll("\n");
         }
     }
 
@@ -517,6 +522,6 @@ pub const UciProtocol = struct {
         for (self.allocated_strings.items) |str| {
             self.allocator.free(str);
         }
-        self.allocated_strings.deinit();
+        self.allocated_strings.deinit(self.allocator);
     }
 };


### PR DESCRIPTION
## Summary
- adapt `std.ArrayList` usage to Zig 0.15's allocator-passing API
- migrate UCI protocol I/O to `std.fs.File` readers and writers
- update best-move reporting and cleanup to avoid removed std.io helpers

## Testing
- /tmp/zig-x86_64-linux-0.15.1/zig build
- /tmp/zig-x86_64-linux-0.15.1/zig build test

------
https://chatgpt.com/codex/tasks/task_e_68d19e8cbccc8324a2fce19afd54dda3