### PR TITLE
Gate debug output behind environment flag

### DIFF
--- a/src/board.zig
+++ b/src/board.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const c = @import("consts.zig");
+const debug = @import("utils/debug.zig");
 // Board Representation
 
 // Board is a 64, bit integer. Each bit represents a square on the board.
@@ -338,11 +339,11 @@ pub const Position = struct {
         }
         for (0..printBuffer.len) |index| {
             if (index % 8 == 0 and index != 0) {
-                std.debug.print("\n", .{});
+                debug.print("\n", .{});
             }
-            std.debug.print("{c}", .{printBuffer[printBuffer.len - 1 - index]});
+            debug.print("{c}", .{printBuffer[printBuffer.len - 1 - index]});
         }
-        std.debug.print("\n", .{});
+        debug.print("\n", .{});
         return printBuffer;
     }
 };
@@ -386,7 +387,7 @@ pub fn parseFen(fen: []const u8) Position {
     const first_token = tokens.next();
     if (first_token == null) {
         // Invalid: no piece placement
-        std.debug.print("FEN string empty or invalid piece placement\n", .{});
+        debug.print("FEN string empty or invalid piece placement\n", .{});
         return Position.emptyboard();
     }
 
@@ -428,7 +429,7 @@ pub fn parseFen(fen: []const u8) Position {
                                 }
                             }
                             if (!placed) {
-                                std.debug.print("Too many white queens in FEN\n", .{});
+                                debug.print("Too many white queens in FEN\n", .{});
                             }
                         }
                     },
@@ -457,7 +458,7 @@ pub fn parseFen(fen: []const u8) Position {
                                 }
                             }
                             if (!placed) {
-                                std.debug.print("Too many white rooks in FEN\n", .{});
+                                debug.print("Too many white rooks in FEN\n", .{});
                             }
                         }
                     },
@@ -486,7 +487,7 @@ pub fn parseFen(fen: []const u8) Position {
                                 }
                             }
                             if (!placed) {
-                                std.debug.print("Too many white bishops in FEN\n", .{});
+                                debug.print("Too many white bishops in FEN\n", .{});
                             }
                         }
                     },
@@ -515,7 +516,7 @@ pub fn parseFen(fen: []const u8) Position {
                                 }
                             }
                             if (!placed) {
-                                std.debug.print("Too many white knights in FEN\n", .{});
+                                debug.print("Too many white knights in FEN\n", .{});
                             }
                         }
                     },
@@ -552,7 +553,7 @@ pub fn parseFen(fen: []const u8) Position {
                                 }
                             }
                             if (!placed) {
-                                std.debug.print("Too many black queens in FEN\n", .{});
+                                debug.print("Too many black queens in FEN\n", .{});
                             }
                         }
                     },
@@ -581,7 +582,7 @@ pub fn parseFen(fen: []const u8) Position {
                                 }
                             }
                             if (!placed) {
-                                std.debug.print("Too many black rooks in FEN\n", .{});
+                                debug.print("Too many black rooks in FEN\n", .{});
                             }
                         }
                     },
@@ -610,7 +611,7 @@ pub fn parseFen(fen: []const u8) Position {
                                 }
                             }
                             if (!placed) {
-                                std.debug.print("Too many black bishops in FEN\n", .{});
+                                debug.print("Too many black bishops in FEN\n", .{});
                             }
                         }
                     },
@@ -639,7 +640,7 @@ pub fn parseFen(fen: []const u8) Position {
                                 }
                             }
                             if (!placed) {
-                                std.debug.print("Too many black knights in FEN\n", .{});
+                                debug.print("Too many black knights in FEN\n", .{});
                             }
                         }
                     },
@@ -691,7 +692,7 @@ pub fn parseFen(fen: []const u8) Position {
     const second_token = tokens.next();
     if (second_token == null) {
         // Invalid: no side to move
-        std.debug.print("FEN string missing side to move\n", .{});
+        debug.print("FEN string missing side to move\n", .{});
     } else {
         // Parse side to move
         const sideToMove = second_token.?;
@@ -812,11 +813,11 @@ test "fen to board" {
     // (@as(piece.type, @field(board.position.whitepieces, piece.name))).position
     inline for (std.meta.fields(@TypeOf(board.position.whitepieces))) |piece| {
         if (@TypeOf(@as(piece.type, @field(board.position.whitepieces, piece.name))) == (Piece)) {
-            std.debug.print("Comparing {s} {}\n", .{ piece.name, @as(u64, @field(board.position.whitepieces, piece.name).position) });
+            debug.print("Comparing {s} {}\n", .{ piece.name, @as(u64, @field(board.position.whitepieces, piece.name).position) });
             try std.testing.expectEqual(@as(u64, @field(board.position.whitepieces, piece.name).position), @as(u64, @field(board2.position.whitepieces, piece.name).position));
         } else if ((@TypeOf(@as(piece.type, @field(board.position.whitepieces, piece.name))) == ([2]Piece)) or (@TypeOf(@as(piece.type, @field(board.position.whitepieces, piece.name))) == ([8]Piece))) {
             inline for (0..@as(piece.type, @field(board.position.whitepieces, piece.name)).len) |i| {
-                std.debug.print("Comparing {s} {} {}\n", .{ piece.name, i, @as(u64, @field(board.position.whitepieces, piece.name)[i].position) });
+                debug.print("Comparing {s} {} {}\n", .{ piece.name, i, @as(u64, @field(board.position.whitepieces, piece.name)[i].position) });
                 try std.testing.expectEqual(@as(u64, @field(board.position.whitepieces, piece.name)[i].position), @as(u64, @field(board2.position.whitepieces, piece.name)[i].position));
             }
         }

--- a/src/eval.zig
+++ b/src/eval.zig
@@ -3,6 +3,7 @@ const b = @import("board.zig");
 const m = @import("moves.zig");
 const s = @import("state.zig");
 const c = @import("consts.zig");
+const debug = @import("utils/debug.zig");
 const Board = b.Board;
 const Piece = b.Piece;
 
@@ -572,8 +573,8 @@ test "minimax finds a move in checkmate position" {
 
     // Print the move for debugging
     if (best_move) |move| {
-        std.debug.print("\nRook position in best move: {}\n", .{move.position.whitepieces.Rook[0].position});
-        std.debug.print("Queen position in best move: {}\n", .{move.position.whitepieces.Queen.position});
+        debug.print("\nRook position in best move: {}\n", .{move.position.whitepieces.Rook[0].position});
+        debug.print("Queen position in best move: {}\n", .{move.position.whitepieces.Queen.position});
     }
 }
 

--- a/src/moves.zig
+++ b/src/moves.zig
@@ -8,6 +8,7 @@ const knight = @import("moves/knight.zig");
 const bishop = @import("moves/bishop.zig");
 const queen = @import("moves/queen.zig");
 const king = @import("moves/king.zig");
+const debug = @import("utils/debug.zig");
 
 // Import the reverse function from board.zig
 const reverse = b.reverse;
@@ -1037,14 +1038,14 @@ test "debug knight move sequence" {
         Move{ .from = c.G8, .to = c.F6, .promotion_piece = null }, // black knight
     };
 
-    std.debug.print("\nInitial position:\n", .{});
+    debug.print("\nInitial position:\n", .{});
     _ = board.print();
 
     for (moves, 0..) |move, i| {
         board = try applyMove(board, move);
-        std.debug.print("\nAfter move {d}:\n", .{i + 1});
+        debug.print("\nAfter move {d}:\n", .{i + 1});
         _ = board.print();
-        std.debug.print("Side to move: {d}\n", .{board.position.sidetomove});
+        debug.print("Side to move: {d}\n", .{board.position.sidetomove});
     }
 }
 

--- a/src/state.zig
+++ b/src/state.zig
@@ -3,6 +3,7 @@ const c = @import("consts.zig");
 const m = @import("moves.zig");
 const attacks = @import("utils/attacks.zig");
 const std = @import("std");
+const debug = @import("utils/debug.zig");
 
 // isCheck determines if the given board position has the king in check
 // It does this by checking if any enemy piece can capture the king in the next move
@@ -361,17 +362,17 @@ test "isCheckmate - Scholar's Mate position" {
     const board = b.Board{ .position = b.parseFen(fen) };
 
     // Print the board state
-    std.debug.print("\nScholar's Mate position:\n", .{});
+    debug.print("\nScholar's Mate position:\n", .{});
     _ = board.print();
-    std.debug.print("Side to move: {d}\n", .{board.position.sidetomove});
+    debug.print("Side to move: {d}\n", .{board.position.sidetomove});
 
     // Check if black is in check
     const blackInCheck = isCheck(board, false);
-    std.debug.print("Black in check: {}\n", .{blackInCheck});
+    debug.print("Black in check: {}\n", .{blackInCheck});
 
     // Check if black is in checkmate
     const blackInCheckmate = isCheckmate(board, false);
-    std.debug.print("Black in checkmate: {}\n", .{blackInCheckmate});
+    debug.print("Black in checkmate: {}\n", .{blackInCheckmate});
 
     try std.testing.expect(blackInCheck);
     // This position is not actually a checkmate, so we don't expect blackInCheckmate to be true

--- a/src/utils/debug.zig
+++ b/src/utils/debug.zig
@@ -1,0 +1,43 @@
+const std = @import("std");
+
+var initialized = false;
+var enabled = false;
+
+fn init() void {
+    if (initialized) return;
+    initialized = true;
+
+    const value = std.process.getEnvVarOwned(std.heap.page_allocator, "CHESS_ENGINE_DEBUG") catch null;
+    defer if (value) |v| std.heap.page_allocator.free(v);
+
+    if (value) |v| {
+        const trimmed = std.mem.trim(u8, v, " \t\n\r");
+        if (trimmed.len == 0) return;
+
+        if (std.ascii.eqlIgnoreCase(trimmed, "1") or
+            std.ascii.eqlIgnoreCase(trimmed, "true") or
+            std.ascii.eqlIgnoreCase(trimmed, "yes") or
+            std.ascii.eqlIgnoreCase(trimmed, "on"))
+        {
+            enabled = true;
+            return;
+        }
+
+        const parsed = std.fmt.parseInt(i64, trimmed, 10) catch null;
+        if (parsed != null) {
+            enabled = parsed.? != 0;
+        }
+    }
+}
+
+pub fn isEnabled() bool {
+    if (!initialized) {
+        init();
+    }
+    return enabled;
+}
+
+pub fn print(comptime fmt: []const u8, args: anytype) void {
+    if (!isEnabled()) return;
+    std.debug.print(fmt, args);
+}


### PR DESCRIPTION
## Summary
- add a reusable debug helper that enables logging only when the CHESS_ENGINE_DEBUG environment variable is truthy
- replace direct std.debug.print usage in board parsing and related tests with the new gated helper to keep runtime UCI output clean

## Testing
- `zig build test --summary all`


------
https://chatgpt.com/codex/tasks/task_e_68d1a8f08ac8832498770d90ba0a1375